### PR TITLE
Add the option to edit a page from the Userbar

### DIFF
--- a/app/$preview/page.tsx
+++ b/app/$preview/page.tsx
@@ -32,7 +32,7 @@ export default async function Preview({
 
   return (
     <>
-      <DynamicUserbar hidden={params.inPreviewPanel === 'true'} />
+      <DynamicUserbar hidden={params.inPreviewPanel === 'true'} pageId={page.id} />
       <PageComponent
         page={page as wagtailcore.Page}
         searchParams={searchParams}

--- a/app/$preview/page.tsx
+++ b/app/$preview/page.tsx
@@ -36,7 +36,10 @@ export default async function Preview({
 
   return (
     <>
-      <DynamicUserbar hidden={params.inPreviewPanel === 'true'} />
+      <DynamicUserbar
+        hidden={params.inPreviewPanel === 'true'}
+        pageId={page.id}
+      />
       <main id="main-content">
         <PageComponent
           page={page as wagtailcore.Page}

--- a/app/[[...path]]/page.tsx
+++ b/app/[[...path]]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
+import DynamicUserbar from '@/components/DynamicUserbar';
 import Breadcrumbs from '@/components/layout/Breadcrumbs';
 import { getPageComponent, type PageType } from '@/components/pages';
 import api from '@/lib/api';
@@ -41,6 +42,7 @@ export default async function Page({ params, searchParams }: PageProps) {
     return (
       <>
         <Breadcrumbs page={basicPage} />
+        <DynamicUserbar pageId={page.id} />
         <main id="main-content">
           <PageComponent page={page} searchParams={searchParams} />
         </main>

--- a/components/Userbar.tsx
+++ b/components/Userbar.tsx
@@ -16,7 +16,7 @@ export default function Userbar({ hidden = false, pageId = null }: { hidden?: bo
 
   useEffect(() => {
     const userbarUrl = `${apiHost}/userbar/${pageId ? `?page_id=${pageId}` : ''}`;
-    fetch(`${apiHost}/userbar/`, { credentials: 'include' })
+    fetch(userbarUrl, { credentials: 'include' })
       .then((res) => res.text())
       .then((userbar) => {
         if (

--- a/components/Userbar.tsx
+++ b/components/Userbar.tsx
@@ -10,12 +10,13 @@ declare global {
   }
 }
 
-export default function Userbar({ hidden = false }: { hidden?: boolean }) {
+export default function Userbar({ hidden = false, pageId = null }: { hidden?: boolean, page_id?: number }) {
   const userbarRef = useRef<HTMLDivElement>(null);
   const apiHost = process.env.NEXT_PUBLIC_WAGTAIL_API_HOST as string;
 
   useEffect(() => {
-    fetch(`${apiHost}/userbar/`)
+    const userbarUrl = `${apiHost}/userbar/${pageId ? `?page_id=${pageId}` : ''}`;
+    fetch(`${apiHost}/userbar/`, { credentials: 'include' })
       .then((res) => res.text())
       .then((userbar) => {
         if (

--- a/components/Userbar.tsx
+++ b/components/Userbar.tsx
@@ -10,7 +10,13 @@ declare global {
   }
 }
 
-export default function Userbar({ hidden = false, pageId = null }: { hidden?: boolean, page_id?: number }) {
+export default function Userbar({
+  hidden = false,
+  pageId,
+}: {
+  hidden?: boolean;
+  pageId?: number;
+}) {
   const userbarRef = useRef<HTMLDivElement>(null);
   const apiHost = process.env.NEXT_PUBLIC_WAGTAIL_API_HOST as string;
 
@@ -28,7 +34,7 @@ export default function Userbar({ hidden = false, pageId = null }: { hidden?: bo
           return;
         userbarRef.current.innerHTML = userbar;
       });
-  }, [apiHost]);
+  }, [apiHost, pageId]);
 
   return (
     <>

--- a/headless-userbar.md
+++ b/headless-userbar.md
@@ -27,7 +27,9 @@ A React component (`Userbar.tsx`) is created to fetch and render the user bar HT
 
 ### 2. Usage in pages
 
-The user bar component is imported and rendered in the relevant pages, such as the preview page. It can be conditionally hidden (e.g., when inside a preview panel) by passing a `hidden` prop.
+The user bar component is imported and rendered in the relevant pages, such as the preview page. It can be conditionally hidden (e.g., when inside a preview panel) by passing a `hidden` prop. If the component
+is given a page ID in the `pageId` attribute, it will render the correct *Edit this page* and other page
+related userbar items.
 
 ### 3. Lazy-loading with dynamic import (optional)
 


### PR DESCRIPTION
I have been experimenting with a headless setup and the dynamic Userbar. What I found lacking is the option to edit a page from the Userbar. This PR along with an edit to the feature in the headless branch of bakerydemo will accomplish that.

The changes needed in the backend to accomplish these changes are:

```diff
class UserbarView(TemplateView):
    template_name = Userbar.template_name
    http_method_names = ["get"]

    def dispatch(self, request, *args, **kwargs):
        response = super().dispatch(request, *args, **kwargs)
        client_url = headless_preview_settings.CLIENT_URLS["default"]
        response["Access-Control-Allow-Origin"] = client_url
        return response

    def get_context_data(self, **kwargs):
+        object = None
+        page_id = self.request.GET.get('page_id', None)
+        if page_id:
+            object = Page.objects.filter(id=page_id).first()

-        return Userbar(object=None, position="bottom-left").get_context_data(
+        return Userbar(object=object, position="bottom-left").get_context_data(
            super().get_context_data(request=self.request, **kwargs)
        )
```