### PR TITLE
Fix inconsistent image aspect ratio in PictureCard

### DIFF
--- a/components/cards/PictureCard.tsx
+++ b/components/cards/PictureCard.tsx
@@ -25,7 +25,14 @@ export default function PictureCard({
   return (
     <div className="picture-card">
       <Link className="picture-card__link" href={url}>
-        <figure className="picture-card__image">
+        <figure
+          className="picture-card__image"
+          style={{
+            overflow: 'hidden',
+            width: '100%',
+            aspectRatio: portrait ? '433/487' : '645/480',
+          }}
+        >
           <Image
             src={image.meta.download_url}
             alt={image.title}
@@ -33,6 +40,11 @@ export default function PictureCard({
             height={height}
             sizes={sizes}
             loading="lazy"
+            style={{
+              objectFit: 'cover',
+              width: '100%',
+              height: '100%',
+            }}
           />
           <div className="picture-card__contents">
             <Heading className="picture-card__title">{title}</Heading>


### PR DESCRIPTION
Fixes #6

### Description
I was going through the bakerydemo-nextjs 
project and noticed that images on the 
Locations and Gallery pages looked different 
from each other. Some images were stretched 
and some were cropped unevenly which made 
the cards look inconsistent.

I looked into the PictureCard component and 
found that there was no object-fit or fixed 
aspect ratio applied to the images. So I 
added those styles to fix the issue.

### Changes Made
- Added objectFit cover to the Image component
- Added aspectRatio to the figure based on 
  portrait or landscape mode
- Added overflow hidden to the figure element

### Testing
I tested this on both the Locations page and 
the Gallery page. The images now look 
consistent and the card heights are uniform.

### AI usage
None