### PR TITLE
Migrate API usage to v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,7 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
+# fetched OpenAPI spec (see `npm run generate-api`)
+/lib/generated/openapi.json
+
 bakerydemo

--- a/app/[[...path]]/page.tsx
+++ b/app/[[...path]]/page.tsx
@@ -15,7 +15,7 @@ export async function generateMetadata({
 }: PageProps): Promise<Metadata> {
   const { path: pathSplit = [] } = await params;
   const path = `/${pathSplit.join('/')}`;
-  const basicPage = await api.getPage(path, 'wagtailcore.Page');
+  const basicPage = await api.getPage(path);
   return {
     title: basicPage.meta.seo_title || basicPage.title,
     description: basicPage.meta.search_description,
@@ -27,21 +27,12 @@ export default async function Page({ params, searchParams }: PageProps) {
   const path = `/${pathSplit.join('/')}`;
 
   try {
-    // First fetch to get the specific page type
-    const basicPage = await api.getPage(path, 'wagtailcore.Page');
-
-    // Get the specific page type from meta
-    const pageType = basicPage.meta.type as PageType;
-
-    // Check if we have a component for this page type
-    const PageComponent = getPageComponent(pageType);
-
-    // Second fetch to get the full page data with the specific type
-    const page = await api.getPage(basicPage.id, pageType);
+    const page = await api.getPage(path);
+    const PageComponent = getPageComponent(page.meta.type as PageType);
 
     return (
       <>
-        <Breadcrumbs page={basicPage} />
+        <Breadcrumbs page={page} />
         <DynamicUserbar pageId={page.id} />
         <main id="main-content">
           <PageComponent page={page} searchParams={searchParams} />

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["**/*"]
+    "includes": ["**/*", "!lib/generated"]
   },
   "formatter": {
     "enabled": true,

--- a/components/LocationCard.tsx
+++ b/components/LocationCard.tsx
@@ -17,12 +17,12 @@ export default function LocationCard({ location }: LocationCardProps) {
     <div className="location-card col-sm-4">
       <Link className="location-card__link" href={location.meta.html_path}>
         <figure className="location-card__image">
-          {location.image && (
+          {location.image_location_card && (
             <Image
-              src={location.image.meta.download_url}
-              alt={location.image.title}
-              width={430}
-              height={320}
+              src={location.image_location_card.full_url}
+              alt={location.image_location_card.alt}
+              width={location.image_location_card.width}
+              height={location.image_location_card.height}
               sizes="(max-width: 768px) 150px, 400px"
               loading="lazy"
             />

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -2,7 +2,7 @@ import { getMenuItems } from '@/lib/menu';
 import { NavigationLinks } from './NavigationLinks';
 
 export default async function Navigation() {
-  const menuItems = await getMenuItems();
+  const menuItems = await getMenuItems().catch(() => []);
 
   return (
     <header className="header clearfix">

--- a/components/cards/BlogListingCard.tsx
+++ b/components/cards/BlogListingCard.tsx
@@ -12,8 +12,8 @@ function truncateWords(text: string, count: number): string {
 interface BlogListingCardProps {
   url: string;
   title: string;
-  image?: wagtailimages.Image | null;
-  introduction?: string;
+  image?: wagtailimages.ImageRendition;
+  introduction?: string | null;
   date_published?: string | null;
   authors?: string[];
 }
@@ -32,10 +32,10 @@ export default function BlogListingCard({
         {image && (
           <figure className="blog-listing-card__image">
             <Image
-              src={image.meta.download_url}
-              alt={image.title}
-              width={322}
-              height={247}
+              src={image.full_url}
+              alt={image.alt}
+              width={image.width}
+              height={image.height}
               loading="lazy"
             />
           </figure>

--- a/components/cards/ListingCard.test.tsx
+++ b/components/cards/ListingCard.test.tsx
@@ -3,12 +3,11 @@ import { describe, expect, it } from 'vitest';
 import ListingCard from '@/components/cards/ListingCard';
 
 const fakeImage = {
-  id: 1,
-  title: 'Test image',
-  meta: {
-    type: 'wagtailimages.Image',
-    download_url: '/media/images/test.jpg',
-  },
+  url: '/media/images/test.jpg',
+  full_url: 'http://localhost:8000/media/images/test.jpg',
+  width: 180,
+  height: 180,
+  alt: 'Test image',
 };
 
 describe('ListingCard', () => {

--- a/components/cards/ListingCard.tsx
+++ b/components/cards/ListingCard.tsx
@@ -10,7 +10,7 @@ interface ListingCardMeta {
 interface ListingCardProps {
   url: string;
   title: string;
-  image?: wagtailimages.Image | null;
+  image?: wagtailimages.ImageRendition;
   h2?: boolean;
   meta?: ListingCardMeta[];
 }
@@ -30,10 +30,10 @@ export default function ListingCard({
         {image && (
           <figure className="listing-card__image">
             <Image
-              src={image.meta.download_url}
-              alt={image.title}
-              width={180}
-              height={180}
+              src={image.full_url}
+              alt={image.alt}
+              width={image.width}
+              height={image.height}
               loading="lazy"
             />
           </figure>

--- a/components/cards/PictureCard.test.tsx
+++ b/components/cards/PictureCard.test.tsx
@@ -3,12 +3,11 @@ import { describe, expect, it } from 'vitest';
 import PictureCard from '@/components/cards/PictureCard';
 
 const fakeImage = {
-  id: 1,
-  title: 'Test image',
-  meta: {
-    type: 'wagtailimages.Image',
-    download_url: '/media/images/test.jpg',
-  },
+  url: '/media/images/test.jpg',
+  full_url: 'http://localhost:8000/media/images/test.jpg',
+  width: 645,
+  height: 480,
+  alt: 'Test image',
 };
 
 describe('PictureCard', () => {
@@ -35,20 +34,11 @@ describe('PictureCard', () => {
     );
   });
 
-  it('sets different image sizes for portrait vs landscape', () => {
-    const { rerender } = render(
-      <PictureCard url="/test" title="Test" image={fakeImage} />,
-    );
-    const landscapeImg = screen.getByRole('img');
-    expect(landscapeImg).toHaveAttribute('width', '645');
-    expect(landscapeImg).toHaveAttribute('height', '480');
-
-    rerender(
-      <PictureCard url="/test" title="Test" image={fakeImage} portrait />,
-    );
-    const portraitImg = screen.getByRole('img');
-    expect(portraitImg).toHaveAttribute('width', '433');
-    expect(portraitImg).toHaveAttribute('height', '487');
+  it('renders the image at the dimensions provided by its rendition', () => {
+    render(<PictureCard url="/test" title="Test" image={fakeImage} />);
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('width', '645');
+    expect(img).toHaveAttribute('height', '480');
   });
 
   it('renders the required BEM class structure', () => {

--- a/components/cards/PictureCard.tsx
+++ b/components/cards/PictureCard.tsx
@@ -5,7 +5,7 @@ import type { wagtailimages } from '@/models';
 interface PictureCardProps {
   url: string;
   title: string;
-  image: wagtailimages.Image;
+  image: wagtailimages.ImageRendition;
   portrait?: boolean;
 }
 
@@ -16,8 +16,6 @@ export default function PictureCard({
   portrait = false,
 }: PictureCardProps) {
   const Heading = portrait ? 'h3' : 'h2';
-  const width = portrait ? 433 : 645;
-  const height = portrait ? 487 : 480;
   const sizes = portrait
     ? '(max-width: 768px) 125px, 400px'
     : '(max-width: 768px) 150px, 30vw';
@@ -27,10 +25,10 @@ export default function PictureCard({
       <Link className="picture-card__link" href={url}>
         <figure className="picture-card__image">
           <Image
-            src={image.meta.download_url}
-            alt={image.title}
-            width={width}
-            height={height}
+            src={image.full_url}
+            alt={image.alt}
+            width={image.width}
+            height={image.height}
             sizes={sizes}
             loading="lazy"
           />

--- a/components/headers/HeaderBlog.test.tsx
+++ b/components/headers/HeaderBlog.test.tsx
@@ -3,12 +3,11 @@ import { describe, expect, it } from 'vitest';
 import HeaderBlog from '@/components/headers/HeaderBlog';
 
 const fakeImage = {
-  id: 1,
-  title: 'Hero image',
-  meta: {
-    type: 'wagtailimages.Image',
-    download_url: '/media/images/hero.jpg',
-  },
+  url: '/media/images/hero.jpg',
+  full_url: 'http://localhost:8000/media/images/hero.jpg',
+  width: 1920,
+  height: 600,
+  alt: 'Hero image',
 };
 
 describe('HeaderBlog', () => {

--- a/components/headers/HeaderBlog.tsx
+++ b/components/headers/HeaderBlog.tsx
@@ -4,10 +4,10 @@ import type { wagtailimages } from '@/models';
 
 interface HeaderBlogProps {
   title: string;
-  subtitle?: string;
-  introduction?: string;
+  subtitle?: string | null;
+  introduction?: string | null;
   date_published?: string | null;
-  image?: wagtailimages.Image | null;
+  image?: wagtailimages.ImageRendition;
 }
 
 export default function HeaderBlog({
@@ -22,10 +22,10 @@ export default function HeaderBlog({
       {image && (
         <div className="container-fluid hero hero--blog">
           <Image
-            src={image.meta.download_url}
-            alt=""
-            width={1920}
-            height={600}
+            src={image.full_url}
+            alt={image.alt}
+            width={image.width}
+            height={image.height}
             sizes="100vw"
             className="hero-image"
             priority

--- a/components/headers/HeaderHero.test.tsx
+++ b/components/headers/HeaderHero.test.tsx
@@ -3,12 +3,11 @@ import { describe, expect, it } from 'vitest';
 import HeaderHero from '@/components/headers/HeaderHero';
 
 const fakeImage = {
-  id: 1,
-  title: 'Hero image',
-  meta: {
-    type: 'wagtailimages.Image',
-    download_url: '/media/images/hero.jpg',
-  },
+  url: '/media/images/hero.jpg',
+  full_url: 'http://localhost:8000/media/images/hero.jpg',
+  width: 1920,
+  height: 600,
+  alt: 'Hero image',
 };
 
 describe('HeaderHero', () => {
@@ -27,7 +26,7 @@ describe('HeaderHero', () => {
   });
 
   it('renders plain title in grid layout when no image', () => {
-    const { container } = render(<HeaderHero title="Sourdough" image={null} />);
+    const { container } = render(<HeaderHero title="Sourdough" />);
     expect(container.querySelector('.container-fluid')).toBeNull();
     expect(container.querySelector('.hero-image')).toBeNull();
     expect(container.querySelector('.container')).toBeInTheDocument();
@@ -37,9 +36,9 @@ describe('HeaderHero', () => {
     );
   });
 
-  it('sets hero image alt to empty string (decorative)', () => {
+  it('sets hero image alt from the rendition', () => {
     const { container } = render(<HeaderHero title="Test" image={fakeImage} />);
     const img = container.querySelector('img.hero-image');
-    expect(img).toHaveAttribute('alt', '');
+    expect(img).toHaveAttribute('alt', 'Hero image');
   });
 });

--- a/components/headers/HeaderHero.tsx
+++ b/components/headers/HeaderHero.tsx
@@ -3,7 +3,7 @@ import type { wagtailimages } from '@/models';
 
 interface HeaderHeroProps {
   title: string;
-  image: wagtailimages.Image | null;
+  image?: wagtailimages.ImageRendition;
 }
 
 export default function HeaderHero({ title, image }: HeaderHeroProps) {
@@ -11,10 +11,10 @@ export default function HeaderHero({ title, image }: HeaderHeroProps) {
     return (
       <div className="container-fluid hero">
         <Image
-          src={image.meta.download_url}
-          alt=""
-          width={1920}
-          height={600}
+          src={image.full_url}
+          alt={image.alt}
+          width={image.width}
+          height={image.height}
           sizes="100vw"
           className="hero-image"
           priority

--- a/components/headers/HeaderIndex.tsx
+++ b/components/headers/HeaderIndex.tsx
@@ -1,6 +1,6 @@
 interface HeaderIndexProps {
   title: string;
-  introduction?: string;
+  introduction?: string | null;
 }
 
 export default function HeaderIndex({ title, introduction }: HeaderIndexProps) {

--- a/components/pages/BlogIndexPage.tsx
+++ b/components/pages/BlogIndexPage.tsx
@@ -49,7 +49,7 @@ export default async function BlogIndexPage({
                 key={post.id}
                 url={post.meta.html_path}
                 title={post.title}
-                image={post.image}
+                image={post.image_listing}
                 introduction={post.introduction}
                 date_published={post.date_published}
                 authors={post.blog_person_relationship.map(

--- a/components/pages/BlogPage.tsx
+++ b/components/pages/BlogPage.tsx
@@ -14,7 +14,7 @@ export default async function BlogPage({
         subtitle={page.subtitle}
         introduction={page.introduction}
         date_published={page.date_published}
-        image={page.image}
+        image={page.image_hero}
       />
 
       <div className="container">

--- a/components/pages/BreadPage.tsx
+++ b/components/pages/BreadPage.tsx
@@ -8,7 +8,7 @@ export default async function BreadPage({
 }: PageComponentProps<breads.BreadPage>) {
   return (
     <>
-      <HeaderHero title={page.title} image={page.image} />
+      <HeaderHero title={page.title} image={page.image_hero} />
 
       <div className="container bread-detail">
         <div className="row">
@@ -29,6 +29,9 @@ export default async function BreadPage({
             <div className="col-md-4 col-md-offset-1">
               <div className="row">
                 <div className="bread-detail__meta">
+                  {/* v3 migration: origin (breads.Country) removed - no
+                  snippet API endpoint exists for Country in v3-preview, so
+                  its title can't be resolved. Was:
                   {page.origin && (
                     <>
                       <p className="bread-detail__meta-title">Origin</p>
@@ -37,6 +40,7 @@ export default async function BreadPage({
                       </p>
                     </>
                   )}
+                  */}
                   {page.bread_type && (
                     <>
                       <p className="bread-detail__meta-title">Type</p>
@@ -51,8 +55,7 @@ export default async function BreadPage({
                       <ul>
                         {page.ingredients.map((ingredient) => (
                           <li key={ingredient.id}>
-                            {ingredient.meta.type ===
-                            'breads.BreadIngredient' ? (
+                            {'name' in ingredient ? (
                               ingredient.name
                             ) : (
                               <span className="bread-detail__meta-ingredient--draft">

--- a/components/pages/BreadsIndexPage.tsx
+++ b/components/pages/BreadsIndexPage.tsx
@@ -18,15 +18,15 @@ export default async function BreadsIndexPage({
   const pageSize = 12;
   const offset = (currentPage - 1) * pageSize;
 
-  const { items: breads, meta } = page.id
+  const { items: breads, count } = page.id
     ? await api.getPages('breads.BreadPage', {
         child_of: page.id.toString(),
         limit: pageSize.toString(),
         offset: offset.toString(),
       })
-    : { items: [], meta: { total_count: 0 } };
+    : { items: [], count: 0 };
 
-  const totalPages = Math.ceil(meta.total_count / pageSize);
+  const totalPages = Math.ceil(count / pageSize);
 
   return (
     <>
@@ -39,12 +39,15 @@ export default async function BreadsIndexPage({
               <ListingCard
                 url={bread.meta.html_path}
                 title={bread.title}
-                image={bread.image}
+                image={bread.image_listing}
                 h2
                 meta={[
+                  /* v3 migration: origin (breads.Country) removed from meta -
+                    no snippet API endpoint exists for Country in v3-preview.
                   ...(bread.origin
                     ? [{ label: 'Origin', value: bread.origin.title }]
                     : []),
+                  */
                   ...(bread.bread_type
                     ? [{ label: 'Type', value: bread.bread_type.title }]
                     : []),
@@ -55,7 +58,7 @@ export default async function BreadsIndexPage({
         </ul>
       </div>
 
-      {meta.total_count > pageSize && (
+      {count > pageSize && (
         <div className="container">
           <div className="row">
             <div className="col-sm-12">

--- a/components/pages/GalleryPage.tsx
+++ b/components/pages/GalleryPage.tsx
@@ -13,7 +13,7 @@ export default async function GalleryPage({
 
   return (
     <>
-      <HeaderHero title={page.title} image={page.image} />
+      <HeaderHero title={page.title} image={page.image_hero} />
 
       <div className="container gallery__container">
         <div className="row">

--- a/components/pages/HomePage.tsx
+++ b/components/pages/HomePage.tsx
@@ -42,12 +42,12 @@ export default async function HomePage({
   return (
     <div className="homepage">
       <div className="container-fluid hero">
-        {page.image && (
+        {page.image_hero && (
           <Image
-            src={page.image.meta.download_url}
-            alt=""
-            width={1920}
-            height={900}
+            src={page.image_hero.full_url}
+            alt={page.image_hero.alt}
+            width={page.image_hero.width}
+            height={page.image_hero.height}
             sizes="100vw"
             className="hero-image"
             priority
@@ -88,8 +88,12 @@ export default async function HomePage({
                       <ListingCard
                         url={child.meta.html_path}
                         title={child.title}
-                        image={child.image}
+                        image={child.image_listing}
                         meta={[
+                          /*
+                          v3 migration: origin (breads.Country) removed
+                          from meta - no snippet API endpoint exists for
+                          Country in v3-preview.
                           ...(child.origin
                             ? [
                                 {
@@ -98,6 +102,7 @@ export default async function HomePage({
                                 },
                               ]
                             : []),
+                        */
                           ...(child.bread_type
                             ? [
                                 {
@@ -128,13 +133,13 @@ export default async function HomePage({
                 )}
               </div>
             )}
-            {page.lead_image && (
+            {page.lead_image_promo && (
               <figure>
                 <Image
-                  src={page.lead_image.meta.download_url}
-                  alt={page.lead_image.title}
-                  width={590}
-                  height={413}
+                  src={page.lead_image_promo.full_url}
+                  alt={page.lead_image_promo.alt}
+                  width={page.lead_image_promo.width}
+                  height={page.lead_image_promo.height}
                 />
               </figure>
             )}
@@ -183,7 +188,7 @@ export default async function HomePage({
                       key={child.id}
                       url={child.meta.html_path}
                       title={child.title}
-                      image={child.image!}
+                      image={child.image_picture_card!}
                       portrait
                     />
                   ))}

--- a/components/pages/LocationPage.tsx
+++ b/components/pages/LocationPage.tsx
@@ -8,7 +8,7 @@ export default async function LocationPage({
 }: PageComponentProps<locations.LocationPage>) {
   return (
     <>
-      <HeaderHero title={page.title} image={page.image} />
+      <HeaderHero title={page.title} image={page.image_hero} />
 
       <div className="container bread-detail">
         <div className="row">

--- a/components/pages/LocationsIndexPage.tsx
+++ b/components/pages/LocationsIndexPage.tsx
@@ -24,7 +24,7 @@ export default async function LocationsIndexPage({
               key={location.id}
               url={location.meta.html_path}
               title={location.title}
-              image={location.image!}
+              image={location.image_picture_card!}
             />
           ))}
         </div>

--- a/components/pages/PeopleIndexPage.tsx
+++ b/components/pages/PeopleIndexPage.tsx
@@ -18,15 +18,15 @@ export default async function PeopleIndexPage({
   const pageSize = 12;
   const offset = (currentPage - 1) * pageSize;
 
-  const { items: persons, meta } = page.id
+  const { items: persons, count } = page.id
     ? await api.getPages('people.PersonPage', {
         child_of: page.id.toString(),
         limit: pageSize.toString(),
         offset: offset.toString(),
       })
-    : { items: [], meta: { total_count: 0 } };
+    : { items: [], count: 0 };
 
-  const totalPages = Math.ceil(meta.total_count / pageSize);
+  const totalPages = Math.ceil(count / pageSize);
 
   return (
     <>
@@ -39,14 +39,14 @@ export default async function PeopleIndexPage({
               <ListingCard
                 url={person.meta.html_path}
                 title={person.title}
-                image={person.image}
+                image={person.image_listing}
               />
             </li>
           ))}
         </ul>
       </div>
 
-      {meta.total_count > pageSize && (
+      {count > pageSize && (
         <div className="container">
           <div className="row">
             <div className="col-sm-12">

--- a/components/pages/PersonPage.tsx
+++ b/components/pages/PersonPage.tsx
@@ -109,7 +109,7 @@ export default async function PersonPage({
 }: PageComponentProps<people.PersonPage>) {
   return (
     <>
-      <HeaderHero title={page.title} image={page.image} />
+      <HeaderHero title={page.title} image={page.image_hero} />
 
       <div className="container bread-detail">
         <div className="row">
@@ -130,6 +130,9 @@ export default async function PersonPage({
             <div className="col-md-4 col-md-offset-1">
               <div className="row">
                 <div className="bread-detail__meta">
+                  {/* v3 migration: location (breads.Country) removed - no
+                  snippet API endpoint exists for Country in v3-preview, so
+                  its title can't be resolved. Was:
                   {page.location && (
                     <>
                       <p className="bread-detail__meta-title">Location</p>
@@ -138,6 +141,7 @@ export default async function PersonPage({
                       </p>
                     </>
                   )}
+                  */}
                   {page.social_links.length > 0 && (
                     <>
                       <p className="bread-detail__meta-title">Socials</p>

--- a/components/pages/StandardPage.tsx
+++ b/components/pages/StandardPage.tsx
@@ -8,7 +8,7 @@ export default async function StandardPage({
 }: PageComponentProps<base.StandardPage>) {
   return (
     <>
-      <HeaderHero title={page.title} image={page.image} />
+      <HeaderHero title={page.title} image={page.image_hero} />
 
       <div className="container bread-detail">
         <div className="row">

--- a/components/streamfield/CaptionedImageBlock.tsx
+++ b/components/streamfield/CaptionedImageBlock.tsx
@@ -6,15 +6,15 @@ export default function CaptionedImageBlock({
 }: {
   block: blocks.CaptionedImageBlock;
 }) {
-  const { meta } = value.image;
+  const { rendition } = value.image.meta;
 
   return (
     <figure>
       <Image
-        src={meta.download_url}
-        alt={value.image.title}
-        width={640}
-        height={480}
+        src={rendition.full_url}
+        alt={rendition.alt}
+        width={rendition.width}
+        height={rendition.height}
         loading="lazy"
       />
       <figcaption>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,274 +1,289 @@
 import { cache } from 'react';
-import { z } from 'zod';
-import { type ContentType, getSchema, type Schema } from '@/models';
+import type { z } from 'zod';
+import {
+  type ContentType,
+  getSchema,
+  type Schema,
+  type wagtailcore,
+} from '@/models';
+import wagtailimages from '@/models/wagtailimages';
 
-// Helper to get the underlying schema, bypassing transforms
-const getBaseSchema = (schema: z.ZodType): z.ZodObject => {
-  if (schema instanceof z.ZodPipe) {
-    return getBaseSchema(schema.in as z.ZodType);
-  }
-  if (schema instanceof z.ZodNullable) {
-    return getBaseSchema(schema.unwrap() as z.ZodType);
-  }
-  return schema as z.ZodObject;
-};
-
-// Helper to get relation fields recursively
-const getRelationFields = (schema: z.ZodType): string[] => {
-  const baseSchema = getBaseSchema(schema);
-  const fields: string[] = [];
-
-  // Get all fields except meta
-  for (const [fieldName, fieldSchema] of Object.entries(baseSchema.shape)) {
-    if (fieldName === 'meta') continue;
-
-    const innerSchema =
-      fieldSchema instanceof z.ZodNullable ? fieldSchema.unwrap() : fieldSchema;
-
-    if (innerSchema instanceof z.ZodObject && 'id' in innerSchema.shape) {
-      // This is a relation, get its fields recursively
-      const relationFields = getRelationFields(innerSchema);
-      fields.push(`${fieldName}(${relationFields.join(',')})`);
-    } else {
-      fields.push(fieldName);
-    }
-  }
-
-  // Include meta's fields
-  if ('meta' in baseSchema.shape) {
-    const metaSchema = baseSchema.shape.meta;
-    const baseMetaSchema = getBaseSchema(metaSchema);
-
-    fields.push(
-      ...Object.keys(baseMetaSchema.shape).filter(
-        (field) => field !== 'parent' && field !== 'html_path',
-      ),
-    );
-  }
-
-  return fields;
-};
-
-// Helper to get field names from a schema, including nested fields for relations
-function getSchemaFields(schema: ReturnType<typeof getSchema>): string[] {
-  const fields: string[] = [];
-
-  const baseSchema = getBaseSchema(schema);
-
-  // Process non-meta fields
-  for (const [fieldName, fieldSchema] of Object.entries(baseSchema.shape)) {
-    if (fieldName === 'meta') continue;
-
-    const innerSchema =
-      fieldSchema instanceof z.ZodNullable ? fieldSchema.unwrap() : fieldSchema;
-
-    if (innerSchema instanceof z.ZodArray) {
-      // For arrays, check the element schema
-      const elementSchema = innerSchema.element;
-      // If the array element is an object, check its fields for relations
-      if (elementSchema instanceof z.ZodObject) {
-        const elementFields = [];
-        for (const [elemField, elemSchema] of Object.entries(
-          elementSchema.shape,
-        )) {
-          if (elemField === 'meta') continue;
-          const innerElemSchema =
-            elemSchema instanceof z.ZodNullable
-              ? elemSchema.unwrap()
-              : elemSchema;
-          if (
-            innerElemSchema instanceof z.ZodObject &&
-            'id' in innerElemSchema.shape
-          ) {
-            // This is a relation within the array element
-            const relationFields = getRelationFields(innerElemSchema);
-            elementFields.push(`${elemField}(${relationFields.join(',')})`);
-          } else {
-            elementFields.push(elemField);
-          }
-        }
-        fields.push(`${fieldName}(${elementFields.join(',')})`);
-      } else {
-        fields.push(fieldName);
-      }
-    } else if (
-      innerSchema instanceof z.ZodObject &&
-      'id' in innerSchema.shape
-    ) {
-      // Direct relation
-      const relationFields = getRelationFields(innerSchema);
-      fields.push(`${fieldName}(${relationFields.join(',')})`);
-    } else {
-      fields.push(fieldName);
-    }
-  }
-
-  // Add top-level meta fields
-  if ('meta' in baseSchema.shape) {
-    const metaSchema = baseSchema.shape.meta;
-    const baseMetaSchema = getBaseSchema(metaSchema);
-
-    fields.push(
-      ...Object.keys(baseMetaSchema.shape).filter(
-        (field) => field !== 'parent' && field !== 'html_path',
-      ),
-    );
-  }
-
-  return fields;
-}
+const apiHost = process.env.NEXT_PUBLIC_WAGTAIL_API_HOST!;
+const apiToken = process.env.WAGTAIL_API_TOKEN;
 
 interface PageResponse<T> {
-  meta: {
-    total_count: number;
-  };
+  count: number;
   items: T[];
 }
 
-interface APIConfig {
-  apiHost: string;
+async function apiFetch<T>(
+  endpoint: string,
+  { auth = false }: { auth?: boolean } = {},
+): Promise<T> {
+  const headers: HeadersInit = { 'Content-Type': 'application/json' };
+  if (auth && apiToken) {
+    headers.Authorization = `Bearer ${apiToken}`;
+  }
+
+  const response = await fetch(`${apiHost}${endpoint}`, { headers });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(
+      `API Error: ${response.status} ${response.statusText}${
+        errorData.message ? ` - ${errorData.message}` : ''
+      }`,
+    );
+  }
+
+  return response.json();
 }
 
-export class WagtailAPI {
-  private apiHost: string;
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
 
-  constructor(config: APIConfig) {
-    this.apiHost = config.apiHost.replace(/\/$/, '');
-  }
-
-  private async fetch<T>(endpoint: string): Promise<T> {
-    const headers: HeadersInit = {
-      'Content-Type': 'application/json',
-    };
-
-    const response = await fetch(`${this.apiHost}${endpoint}`, { headers });
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(
-        `API Error: ${response.status} ${response.statusText}${
-          errorData.message ? ` - ${errorData.message}` : ''
-        }`,
-      );
-    }
-
-    return response.json();
-  }
-
-  /**
-   * Get a single page by path or ID
-   */
-  async getPage<CT extends ContentType>(
-    id: number,
-    contentType: CT,
-  ): Promise<z.output<Schema<CT>>>;
-  async getPage<CT extends ContentType>(
-    path: string,
-    contentType: CT,
-  ): Promise<z.output<Schema<CT>>>;
-  async getPage<CT extends ContentType>(
-    pathOrId: string | number,
-    contentType: CT,
-  ): Promise<z.output<Schema<CT>>> {
-    const schema = getSchema(contentType);
-    // Get base fields and add parent explicitly for detail view
-    const fields = [...getSchemaFields(schema), 'parent'].join(',');
-    let id: number = typeof pathOrId === 'number' ? pathOrId : -1;
-
-    if (id === -1) {
-      // Workaround for https://github.com/wagtail/wagtail/issues/6577
-      const data = await this.fetch<unknown>(
-        `/api/v2/pages/find/?html_path=${pathOrId}&fields=${fields}`,
-      );
-      const page = getSchema('wagtailcore.Page').parse(data);
-      // Return as-is for the base Page type as we don't need any extra fields
-      if (contentType === 'wagtailcore.Page') {
-        return page as z.output<Schema<CT>>;
-      }
-
-      id = page.id;
-    }
-
-    const data = await this.fetch<unknown>(
-      `/api/v2/pages/${id}/?fields=${fields}`,
-    );
-    return schema.parse(data) as z.output<Schema<CT>>;
-  }
-
-  /**
-   * Get pages of a specific type
-   */
-  async getPages<CT extends ContentType>(
-    contentType: CT,
-    params: Record<string, string> = {},
-  ) {
-    const schema = getSchema(contentType);
-    const fields = getSchemaFields(schema).join(',');
-
-    const searchParams = new URLSearchParams({
-      ...params,
-      type: contentType,
-      fields,
-    });
-
-    const data = await this.fetch<PageResponse<unknown>>(
-      `/api/v2/pages/?${searchParams}`,
-    );
-
-    return {
-      ...data,
-      items: data.items.map(
-        (item) => schema.parse(item) as z.output<Schema<CT>>,
-      ),
-    };
-  }
-
-  async getPreview<CT extends ContentType>(
-    contentType: CT,
-    token: string,
-  ): Promise<z.output<Schema<CT>>> {
-    const schema = getSchema(contentType);
-    const fields = getSchemaFields(schema).join(',');
-    const data = await this.fetch<unknown>(
-      `/api/v2/preview/?content_type=${contentType}&token=${token}&fields=${fields}`,
-    );
-    return schema.parse(data) as z.output<Schema<CT>>;
-  }
-
-  /**
-   * Get a single image by ID
-   */
-  async getImage(id: number) {
-    const data = await this.fetch<unknown>(`/api/v2/images/${id}/`);
-    return getSchema('wagtailimages.Image').parse(data);
-  }
-
-  /**
-   * Get images
-   */
-  async getImages(params: Record<string, string> = {}) {
-    const searchParams = new URLSearchParams(params);
-    const data = await this.fetch<PageResponse<unknown>>(
-      `/api/v2/images/?${searchParams}`,
-    );
-
-    return {
-      ...data,
-      items: data.items.map((item) =>
-        getSchema('wagtailimages.Image').parse(item),
-      ),
-    };
-  }
-}
-
-const api = new WagtailAPI({
-  apiHost: process.env.NEXT_PUBLIC_WAGTAIL_API_HOST!,
+/**
+ * Fetch a single image's raw JSON by ID, in place of the thin `{id, meta}`
+ * stubs that v3 nests inside pages/snippets.
+ */
+const getImageRaw = cache(async (id: number) => {
+  return apiFetch<JsonValue>(`/api/v3-preview/images/${id}/`);
 });
 
-api.getPage = cache(api.getPage.bind(api));
-api.getPages = cache(api.getPages.bind(api));
-api.getPreview = cache(api.getPreview.bind(api));
-api.getImage = cache(api.getImage.bind(api));
-api.getImages = cache(api.getImages.bind(api));
+/**
+ * Fetch a single page's raw JSON by ID, in place of the thin `{id, meta}`
+ * FK stubs v3 nests inside pages (e.g. HomePage.hero_cta_link). Only the
+ * base page fields (id/title/meta) are used by callers, but the raw
+ * response is returned as-is (not trimmed) since it's spliced back into a
+ * tree that gets parsed once, as a whole, by the caller.
+ */
+const getPageRaw = cache(async (id: number) => {
+  return apiFetch<JsonValue>(`/api/v3-preview/pages/${id}/`);
+});
+
+/**
+ * Fetch a single snippet's raw JSON by its content type and ID, in place of
+ * the thin `{id, meta}` FK stubs v3 nests inside pages. Unlike pages/images,
+ * v3's snippets endpoint requires authentication (no anonymous access), so
+ * this sends WAGTAIL_API_TOKEN as a bearer token. Returns null if the
+ * snippet can't be resolved (e.g. draft/deleted, or a model with no
+ * snippet API endpoint such as breads.Country), matching how v2's expanded
+ * fields used to silently omit unresolvable relations.
+ */
+const getSnippetRaw = cache(async (contentType: string, id: number) => {
+  try {
+    return await apiFetch<JsonValue>(
+      `/api/v3-preview/snippets/${contentType}/${id}/`,
+      { auth: true },
+    );
+  } catch {
+    return null;
+  }
+});
+
+function isForeignKeyStub(
+  value: JsonValue,
+): value is { id: number | null; meta: { type: string } } {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const keys = Object.keys(value).sort();
+  if (keys.join(',') !== 'id,meta') return false;
+  const meta = value.meta;
+  return (
+    typeof meta === 'object' &&
+    meta !== null &&
+    !Array.isArray(meta) &&
+    typeof meta.type === 'string'
+  );
+}
+
+/**
+ * Recursively replaces thin `{id, meta: {type}}` foreign key stubs (as
+ * returned by v3 for images and snippet/page relations nested inside a
+ * page) with the fully hydrated raw JSON, since v3 has no fields/expand
+ * mechanism to do this server-side. The whole tree is parsed exactly once
+ * by the caller afterwards, so every resolver here returns raw JSON rather
+ * than a parsed object. Page/parent references in `meta` (which carry a
+ * `title` alongside `id`/`meta`) are left untouched, as are bare id lists
+ * (e.g. BreadPage.ingredients).
+ */
+async function hydrateForeignKeys(value: JsonValue): Promise<JsonValue> {
+  if (Array.isArray(value)) {
+    return Promise.all(value.map(hydrateForeignKeys));
+  }
+
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+
+  if (isForeignKeyStub(value)) {
+    if (value.id == null) return value;
+
+    // v3 reports the generic `wagtailcore.Page` type for page FK fields
+    // (e.g. HomePage.hero_cta_link) regardless of the linked page's actual
+    // type. Any FK field resolved via a page fetch - whether reported as
+    // `wagtailcore.Page` or as a fallback below - is NEVER recursed into
+    // further: callers only need id/title/meta.html_path from a linked
+    // page, not its own images/relations, and recursing would re-hydrate
+    // that page's own relations (e.g. a BlogPage's
+    // blog_person_relationship.page pointing right back at it), causing
+    // unbounded/circular fan-out across the site graph.
+    if (value.meta.type === 'wagtailcore.Page') {
+      return (await getPageRaw(value.id).catch(() => null)) ?? value;
+    }
+
+    if (value.meta.type === 'wagtailimages.Image') {
+      const image = await getImageRaw(value.id).catch(() => null);
+      return image ? hydrateForeignKeys(image) : value;
+    }
+
+    // Everything else is tried as a snippet first (small, leaf-like -
+    // safe to recurse into), falling back to a page fetch (never
+    // recursed into) for FK fields whose stub type wasn't a real snippet.
+    const snippet = await getSnippetRaw(value.meta.type, value.id);
+    if (snippet) return hydrateForeignKeys(snippet);
+
+    return (await getPageRaw(value.id).catch(() => null)) ?? value;
+  }
+
+  const entries = await Promise.all(
+    Object.entries(value).map(async ([key, val]) => [
+      key,
+      await hydrateForeignKeys(val),
+    ]),
+  );
+  return Object.fromEntries(entries);
+}
+
+/**
+ * Get a single page by path or ID, resolved to its specific content type.
+ */
+async function getPage<CT extends ContentType = 'wagtailcore.Page'>(
+  id: number,
+): Promise<z.output<Schema<CT>>>;
+async function getPage<CT extends ContentType = 'wagtailcore.Page'>(
+  path: string,
+): Promise<z.output<Schema<CT>>>;
+async function getPage<CT extends ContentType = 'wagtailcore.Page'>(
+  pathOrId: string | number,
+): Promise<z.output<Schema<CT>>> {
+  const raw =
+    typeof pathOrId === 'number'
+      ? await apiFetch<JsonValue>(`/api/v3-preview/pages/${pathOrId}/`)
+      : await apiFetch<JsonValue>(
+          `/api/v3-preview/pages/find/?html_path=${encodeURIComponent(pathOrId)}`,
+        );
+  const data = await hydrateForeignKeys(raw);
+  const schema = getSchema<CT>((data as wagtailcore.Page).meta.type as CT);
+  return schema.parse(data) as z.output<Schema<CT>>;
+}
+
+/**
+ * Find a page by path, returning its raw (un-hydrated) JSON alongside the
+ * resolved content type string from `meta.type`. Used to look up the
+ * specific page type without a redundant second fetch, since v3's
+ * find/detail endpoints already return the full page data in one call -
+ * only the content-type-specific `.parse()` needs to happen a second time
+ * (via `parsePage`).
+ */
+async function findPage(
+  path: string,
+): Promise<{ raw: JsonValue; type: string }> {
+  const raw = await apiFetch<JsonValue>(
+    `/api/v3-preview/pages/find/?html_path=${encodeURIComponent(path)}`,
+  );
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    throw new Error('Unexpected response shape from pages/find/');
+  }
+  const meta = raw.meta;
+  if (typeof meta !== 'object' || meta === null || Array.isArray(meta)) {
+    throw new Error('Unexpected response shape from pages/find/');
+  }
+  return { raw, type: meta.type as string };
+}
+
+/**
+ * Parse the raw JSON from `findPage`/`getPage` against a specific content
+ * type's schema, hydrating any foreign key stubs first.
+ */
+async function parsePage<CT extends ContentType>(
+  raw: JsonValue,
+  contentType: CT,
+): Promise<z.output<Schema<CT>>> {
+  const schema = getSchema(contentType);
+  const data = await hydrateForeignKeys(raw);
+  return schema.parse(data) as z.output<Schema<CT>>;
+}
+
+/**
+ * Get pages of a specific type. The v3 list endpoint only returns
+ * {meta, id, title} per item, so each item is hydrated with a follow-up
+ * detail fetch.
+ */
+async function getPages<CT extends ContentType>(
+  contentType: CT,
+  params: Record<string, string> = {},
+) {
+  const schema = getSchema(contentType);
+  const searchParams = new URLSearchParams({ ...params, type: contentType });
+
+  const data = await apiFetch<PageResponse<{ id: number }>>(
+    `/api/v3-preview/pages/?${searchParams}`,
+  );
+
+  const items = await Promise.all(
+    data.items.map(async (item) => {
+      const raw = await apiFetch<JsonValue>(
+        `/api/v3-preview/pages/${item.id}/`,
+      );
+      const detail = await hydrateForeignKeys(raw);
+      return schema.parse(detail) as z.output<Schema<CT>>;
+    }),
+  );
+
+  return { ...data, items };
+}
+
+async function getPreview<CT extends ContentType>(
+  contentType: CT,
+  token: string,
+): Promise<z.output<Schema<CT>>> {
+  const schema = getSchema(contentType);
+  const raw = await apiFetch<JsonValue>(
+    `/api/v3-preview/preview/?content_type=${contentType}&token=${token}`,
+  );
+  const data = await hydrateForeignKeys(raw);
+  return schema.parse(data) as z.output<Schema<CT>>;
+}
+
+/**
+ * Get images
+ */
+async function getImages(params: Record<string, string> = {}) {
+  const searchParams = new URLSearchParams(params);
+  const data = await apiFetch<PageResponse<unknown>>(
+    `/api/v3-preview/images/?${searchParams}`,
+  );
+
+  return {
+    ...data,
+    items: data.items.map((item) => wagtailimages.Image.parse(item)),
+  };
+}
+
+const api = {
+  getPage: cache(getPage),
+  findPage: cache(findPage),
+  parsePage: cache(parsePage),
+  getPages: cache(getPages),
+  getPreview: cache(getPreview),
+  getImages: cache(getImages),
+};
 
 export default api;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -143,13 +143,15 @@ async function hydrateForeignKeys(value: JsonValue): Promise<JsonValue> {
       return image ? hydrateForeignKeys(image) : value;
     }
 
-    // Everything else is tried as a snippet first (small, leaf-like -
-    // safe to recurse into), falling back to a page fetch (never
-    // recursed into) for FK fields whose stub type wasn't a real snippet.
+    // Everything else is tried as a snippet (small, leaf-like - safe to
+    // recurse into). If it's not a real snippet (e.g. breads.Country,
+    // wagtailcore.Collection - no snippet API endpoint exists for these),
+    // leave the stub as-is. Do NOT fall back to a page fetch here: the
+    // numeric id belongs to whatever model `meta.type` names, not to the
+    // pages table, so treating it as a page id would silently splice in
+    // an unrelated page.
     const snippet = await getSnippetRaw(value.meta.type, value.id);
-    if (snippet) return hydrateForeignKeys(snippet);
-
-    return (await getPageRaw(value.id).catch(() => null)) ?? value;
+    return snippet ? hydrateForeignKeys(snippet) : value;
   }
 
   const entries = await Promise.all(

--- a/lib/generated/schemas.ts
+++ b/lib/generated/schemas.ts
@@ -1,0 +1,2025 @@
+import { z } from "zod";
+
+const ancestor_of = z.union([z.number(), z.null()]).optional();
+const child_of = z.union([z.number(), z.string(), z.null()]).optional();
+const locale = z.union([z.string(), z.null()]).optional();
+const order = z
+  .union([z.string(), z.array(z.string())])
+  .optional()
+  .default([]);
+const search_operator = z.union([z.enum(["and", "or"]), z.null()]).optional();
+const RichTextRemoval = z
+  .object({
+    tag: z.string(),
+    action: z.enum(["unwrapped", "removed"]),
+    reason: z.enum([
+      "feature_disabled",
+      "unknown_linktype",
+      "unknown_embedtype",
+      "missing_attribute",
+    ]),
+    attribute: z.union([z.string(), z.null()]).optional(),
+    detail: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const BasePageMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]).optional(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+    detail_url: z.union([z.string(), z.null()]).optional(),
+    html_url: z.union([z.string(), z.null()]).optional(),
+    locale: z.union([z.string(), z.null()]).optional(),
+    slug: z.string(),
+    first_published_at: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const BasePageSchema = z
+  .object({ meta: BasePageMetaSchema, id: z.number().int(), title: z.string() })
+  .passthrough();
+const PagedBasePageSchema = z
+  .object({ items: z.array(BasePageSchema), count: z.number().int() })
+  .passthrough();
+const StandardPageCreateMetaSchema = z
+  .object({
+    type: z.string(),
+    parent_id: z.number().int(),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const StandardPageCreateSchema = z
+  .object({
+    meta: StandardPageCreateMetaSchema,
+    title: z.string().max(255),
+    slug: z.union([z.string(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
+  })
+  .passthrough();
+const HomePageCreateMetaSchema = z
+  .object({
+    type: z.string(),
+    parent_id: z.number().int(),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const HomePageCreateSchema = z
+  .object({
+    meta: HomePageCreateMetaSchema,
+    title: z.string().max(255),
+    slug: z.union([z.string(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
+  })
+  .passthrough();
+const GalleryPageCreateMetaSchema = z
+  .object({
+    type: z.string(),
+    parent_id: z.number().int(),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const GalleryPageCreateSchema = z
+  .object({
+    meta: GalleryPageCreateMetaSchema,
+    title: z.string().max(255),
+    slug: z.union([z.string(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
+  })
+  .passthrough();
+const FormPageCreateMetaSchema = z
+  .object({
+    type: z.string(),
+    parent_id: z.number().int(),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const FormPageCreateSchema = z
+  .object({
+    meta: FormPageCreateMetaSchema,
+    title: z.string().max(255),
+    slug: z.union([z.string(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
+  })
+  .passthrough();
+const BlogPageCreateMetaSchema = z
+  .object({
+    type: z.string(),
+    parent_id: z.number().int(),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const BlogPersonRelationshipCreateSchema = z
+  .object({ page_id: z.number().int(), person_id: z.number().int() })
+  .passthrough();
+const BlogPageCreateSchema = z
+  .object({
+    meta: BlogPageCreateMetaSchema,
+    title: z.string().max(255),
+    slug: z.union([z.string(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
+    introduction: z.union([z.string(), z.null()]).optional(),
+    image_id: z.union([z.number(), z.null()]).optional(),
+    body: z.array(z.unknown()).optional().default([]),
+    subtitle: z.union([z.string(), z.null()]).optional(),
+    date_published: z.union([z.string(), z.null()]).optional(),
+    blog_person_relationship: z
+      .array(BlogPersonRelationshipCreateSchema)
+      .optional()
+      .default([]),
+  })
+  .passthrough();
+const BlogIndexPageCreateMetaSchema = z
+  .object({
+    type: z.string(),
+    parent_id: z.number().int(),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const BlogIndexPageCreateSchema = z
+  .object({
+    meta: BlogIndexPageCreateMetaSchema,
+    title: z.string().max(255),
+    slug: z.union([z.string(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
+    introduction: z.union([z.string(), z.null()]).optional(),
+    image_id: z.union([z.number(), z.null()]).optional(),
+  })
+  .passthrough();
+const BreadPageCreateMetaSchema = z
+  .object({
+    type: z.string(),
+    parent_id: z.number().int(),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const BreadPageCreateSchema = z
+  .object({
+    meta: BreadPageCreateMetaSchema,
+    title: z.string().max(255),
+    slug: z.union([z.string(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
+  })
+  .passthrough();
+const BreadsIndexPageCreateMetaSchema = z
+  .object({
+    type: z.string(),
+    parent_id: z.number().int(),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const BreadsIndexPageCreateSchema = z
+  .object({
+    meta: BreadsIndexPageCreateMetaSchema,
+    title: z.string().max(255),
+    slug: z.union([z.string(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
+  })
+  .passthrough();
+const LocationsIndexPageCreateMetaSchema = z
+  .object({
+    type: z.string(),
+    parent_id: z.number().int(),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const LocationsIndexPageCreateSchema = z
+  .object({
+    meta: LocationsIndexPageCreateMetaSchema,
+    title: z.string().max(255),
+    slug: z.union([z.string(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
+  })
+  .passthrough();
+const LocationPageCreateMetaSchema = z
+  .object({
+    type: z.string(),
+    parent_id: z.number().int(),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const LocationPageCreateSchema = z
+  .object({
+    meta: LocationPageCreateMetaSchema,
+    title: z.string().max(255),
+    slug: z.union([z.string(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
+  })
+  .passthrough();
+const RecipePageCreateMetaSchema = z
+  .object({
+    type: z.string(),
+    parent_id: z.number().int(),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const RecipePageCreateSchema = z
+  .object({
+    meta: RecipePageCreateMetaSchema,
+    title: z.string().max(255),
+    slug: z.union([z.string(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
+  })
+  .passthrough();
+const RecipeIndexPageCreateMetaSchema = z
+  .object({
+    type: z.string(),
+    parent_id: z.number().int(),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const RecipeIndexPageCreateSchema = z
+  .object({
+    meta: RecipeIndexPageCreateMetaSchema,
+    title: z.string().max(255),
+    slug: z.union([z.string(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
+  })
+  .passthrough();
+const PersonPageCreateMetaSchema = z
+  .object({
+    type: z.string(),
+    parent_id: z.number().int(),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const PersonPageCreateSchema = z
+  .object({
+    meta: PersonPageCreateMetaSchema,
+    title: z.string().max(255),
+    slug: z.union([z.string(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
+  })
+  .passthrough();
+const PeopleIndexPageCreateMetaSchema = z
+  .object({
+    type: z.string(),
+    parent_id: z.number().int(),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const PeopleIndexPageCreateSchema = z
+  .object({
+    meta: PeopleIndexPageCreateMetaSchema,
+    title: z.string().max(255),
+    slug: z.union([z.string(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
+  })
+  .passthrough();
+const pages_create_Body = z.union([
+  StandardPageCreateSchema,
+  HomePageCreateSchema,
+  GalleryPageCreateSchema,
+  FormPageCreateSchema,
+  BlogPageCreateSchema,
+  BlogIndexPageCreateSchema,
+  BreadPageCreateSchema,
+  BreadsIndexPageCreateSchema,
+  LocationsIndexPageCreateSchema,
+  LocationPageCreateSchema,
+  RecipePageCreateSchema,
+  RecipeIndexPageCreateSchema,
+  PersonPageCreateSchema,
+  PeopleIndexPageCreateSchema,
+]);
+const rich_text_format = z
+  .union([z.enum(["db_html", "html", "db_markdown", "markdown"]), z.null()])
+  .optional();
+const SimpleBasePageMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]),
+    warnings: z.union([
+      z.array(z.union([RichTextRemoval, z.string()])),
+      z.null(),
+    ]),
+    detail_url: z.union([z.string(), z.null()]),
+    html_url: z.union([z.string(), z.null()]),
+  })
+  .partial()
+  .passthrough();
+const SimpleBasePageSchema = z
+  .object({
+    meta: SimpleBasePageMetaSchema,
+    id: z.number().int(),
+    title: z.string(),
+  })
+  .passthrough();
+const abc__PageMetaSchema__1 = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+    detail_url: z.union([z.string(), z.null()]).optional(),
+    html_url: z.union([z.string(), z.null()]).optional(),
+    locale: z.union([z.string(), z.null()]).optional(),
+    slug: z.string(),
+    first_published_at: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
+    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
+  })
+  .passthrough();
+const PageSchema = z
+  .object({
+    meta: abc__PageMetaSchema__1,
+    id: z.union([z.number(), z.null()]).optional(),
+    title: z.string(),
+  })
+  .passthrough();
+const StandardPageMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+    detail_url: z.union([z.string(), z.null()]).optional(),
+    html_url: z.union([z.string(), z.null()]).optional(),
+    locale: z.union([z.string(), z.null()]).optional(),
+    slug: z.string(),
+    first_published_at: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
+    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
+  })
+  .passthrough();
+const ImageMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+  })
+  .passthrough();
+const ImageForeignKeySchema = z
+  .object({
+    meta: ImageMetaSchema,
+    id: z.union([z.number(), z.null()]).optional(),
+  })
+  .passthrough();
+const StandardPageSchema = z
+  .object({
+    meta: StandardPageMetaSchema,
+    id: z.number().int(),
+    title: z.string(),
+    introduction: z.union([z.string(), z.null()]).optional(),
+    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
+    body: z.array(z.unknown()).optional().default([]),
+    image_hero: z.unknown().optional(),
+  })
+  .passthrough();
+const HomePageMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+    detail_url: z.union([z.string(), z.null()]).optional(),
+    html_url: z.union([z.string(), z.null()]).optional(),
+    locale: z.union([z.string(), z.null()]).optional(),
+    slug: z.string(),
+    first_published_at: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
+    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
+  })
+  .passthrough();
+const abc__PageMetaSchema__2 = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+  })
+  .passthrough();
+const PageForeignKeySchema = z
+  .object({
+    meta: abc__PageMetaSchema__2,
+    id: z.union([z.number(), z.null()]).optional(),
+  })
+  .passthrough();
+const HomePageSchema = z
+  .object({
+    meta: HomePageMetaSchema,
+    id: z.number().int(),
+    title: z.string(),
+    hero_text: z.string().max(255),
+    hero_cta: z.string().max(255),
+    lead_title: z.union([z.string(), z.null()]).optional(),
+    featured_section_1_title: z.union([z.string(), z.null()]).optional(),
+    featured_section_2_title: z.union([z.string(), z.null()]).optional(),
+    featured_section_3_title: z.union([z.string(), z.null()]).optional(),
+    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
+    hero_cta_link: z.union([PageForeignKeySchema, z.null()]).optional(),
+    body: z.array(z.unknown()).optional().default([]),
+    lead_image: z.union([ImageForeignKeySchema, z.null()]).optional(),
+    lead_text: z.union([z.string(), z.null()]).optional(),
+    featured_section_1: z.union([PageForeignKeySchema, z.null()]).optional(),
+    featured_section_2: z.union([PageForeignKeySchema, z.null()]).optional(),
+    featured_section_3: z.union([PageForeignKeySchema, z.null()]).optional(),
+    image_hero: z.unknown().optional(),
+    lead_image_promo: z.unknown().optional(),
+  })
+  .passthrough();
+const GalleryPageMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+    detail_url: z.union([z.string(), z.null()]).optional(),
+    html_url: z.union([z.string(), z.null()]).optional(),
+    locale: z.union([z.string(), z.null()]).optional(),
+    slug: z.string(),
+    first_published_at: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
+    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
+  })
+  .passthrough();
+const CollectionMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+  })
+  .passthrough();
+const CollectionForeignKeySchema = z
+  .object({
+    meta: CollectionMetaSchema,
+    id: z.union([z.number(), z.null()]).optional(),
+  })
+  .passthrough();
+const GalleryPageSchema = z
+  .object({
+    meta: GalleryPageMetaSchema,
+    id: z.number().int(),
+    title: z.string(),
+    introduction: z.union([z.string(), z.null()]).optional(),
+    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
+    body: z.array(z.unknown()).optional().default([]),
+    collection: z.union([CollectionForeignKeySchema, z.null()]).optional(),
+    image_hero: z.unknown().optional(),
+  })
+  .passthrough();
+const FormPageMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+    detail_url: z.union([z.string(), z.null()]).optional(),
+    html_url: z.union([z.string(), z.null()]).optional(),
+    locale: z.union([z.string(), z.null()]).optional(),
+    slug: z.string(),
+    first_published_at: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
+    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
+  })
+  .passthrough();
+const FormFieldMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+  })
+  .passthrough();
+const FormFieldSchema = z
+  .object({
+    meta: FormFieldMetaSchema,
+    id: z.union([z.number(), z.null()]).optional(),
+    clean_name: z.union([z.string(), z.null()]).optional().default(""),
+    label: z.string().max(255),
+    field_type: z.string().max(16),
+    help_text: z.union([z.string(), z.null()]).optional(),
+    required: z.boolean().optional().default(true),
+    choices: z.union([z.string(), z.null()]).optional(),
+    default_value: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const FormPageSchema = z
+  .object({
+    meta: FormPageMetaSchema,
+    id: z.number().int(),
+    title: z.string(),
+    from_address: z.union([z.string(), z.null()]).optional(),
+    to_address: z.union([z.string(), z.null()]).optional(),
+    subject: z.union([z.string(), z.null()]).optional(),
+    form_fields: z.array(FormFieldSchema).optional().default([]),
+    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
+    body: z.array(z.unknown()).optional().default([]),
+    thank_you_text: z.union([z.string(), z.null()]).optional(),
+    image_hero: z.unknown().optional(),
+  })
+  .passthrough();
+const abc__BlogPageMetaSchema__1 = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+    detail_url: z.union([z.string(), z.null()]).optional(),
+    html_url: z.union([z.string(), z.null()]).optional(),
+    locale: z.union([z.string(), z.null()]).optional(),
+    slug: z.string(),
+    first_published_at: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
+    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
+  })
+  .passthrough();
+const BlogPersonRelationshipMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+  })
+  .passthrough();
+const abc__BlogPageMetaSchema__2 = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+  })
+  .passthrough();
+const BlogPageForeignKeySchema = z
+  .object({
+    meta: abc__BlogPageMetaSchema__2,
+    id: z.union([z.number(), z.null()]).optional(),
+  })
+  .passthrough();
+const PersonMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+  })
+  .passthrough();
+const PersonForeignKeySchema = z
+  .object({
+    meta: PersonMetaSchema,
+    id: z.union([z.number(), z.null()]).optional(),
+  })
+  .passthrough();
+const BlogPersonRelationshipSchema = z
+  .object({
+    meta: BlogPersonRelationshipMetaSchema,
+    id: z.union([z.number(), z.null()]).optional(),
+    page: BlogPageForeignKeySchema.optional(),
+    person: PersonForeignKeySchema.optional(),
+  })
+  .passthrough();
+const BlogPageSchema = z
+  .object({
+    meta: abc__BlogPageMetaSchema__1,
+    id: z.number().int(),
+    title: z.string(),
+    introduction: z.union([z.string(), z.null()]).optional(),
+    subtitle: z.union([z.string(), z.null()]).optional(),
+    date_published: z.union([z.string(), z.null()]).optional(),
+    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
+    body: z.array(z.unknown()).optional().default([]),
+    tags: z.array(z.string()).optional().default([]),
+    blog_person_relationship: z
+      .array(BlogPersonRelationshipSchema)
+      .optional()
+      .default([]),
+    image_hero: z.unknown().optional(),
+    image_listing: z.unknown().optional(),
+    image_picture_card: z.unknown().optional(),
+  })
+  .passthrough();
+const BlogIndexPageMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+    detail_url: z.union([z.string(), z.null()]).optional(),
+    html_url: z.union([z.string(), z.null()]).optional(),
+    locale: z.union([z.string(), z.null()]).optional(),
+    slug: z.string(),
+    first_published_at: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
+    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
+  })
+  .passthrough();
+const BlogIndexPageSchema = z
+  .object({
+    meta: BlogIndexPageMetaSchema,
+    id: z.number().int(),
+    title: z.string(),
+    introduction: z.union([z.string(), z.null()]).optional(),
+    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
+  })
+  .passthrough();
+const BreadPageMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+    detail_url: z.union([z.string(), z.null()]).optional(),
+    html_url: z.union([z.string(), z.null()]).optional(),
+    locale: z.union([z.string(), z.null()]).optional(),
+    slug: z.string(),
+    first_published_at: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
+    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
+  })
+  .passthrough();
+const CountryMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+  })
+  .passthrough();
+const CountryForeignKeySchema = z
+  .object({
+    meta: CountryMetaSchema,
+    id: z.union([z.number(), z.null()]).optional(),
+  })
+  .passthrough();
+const BreadTypeMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+  })
+  .passthrough();
+const BreadTypeForeignKeySchema = z
+  .object({
+    meta: BreadTypeMetaSchema,
+    id: z.union([z.number(), z.null()]).optional(),
+  })
+  .passthrough();
+const BreadPageSchema = z
+  .object({
+    meta: BreadPageMetaSchema,
+    id: z.number().int(),
+    title: z.string(),
+    introduction: z.union([z.string(), z.null()]).optional(),
+    ingredients: z.array(z.number().int()),
+    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
+    body: z.array(z.unknown()).optional().default([]),
+    origin: z.union([CountryForeignKeySchema, z.null()]).optional(),
+    bread_type: z.union([BreadTypeForeignKeySchema, z.null()]).optional(),
+    image_hero: z.unknown().optional(),
+    image_listing: z.unknown().optional(),
+  })
+  .passthrough();
+const BreadsIndexPageMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+    detail_url: z.union([z.string(), z.null()]).optional(),
+    html_url: z.union([z.string(), z.null()]).optional(),
+    locale: z.union([z.string(), z.null()]).optional(),
+    slug: z.string(),
+    first_published_at: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
+    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
+  })
+  .passthrough();
+const BreadsIndexPageSchema = z
+  .object({
+    meta: BreadsIndexPageMetaSchema,
+    id: z.number().int(),
+    title: z.string(),
+    introduction: z.union([z.string(), z.null()]).optional(),
+    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
+  })
+  .passthrough();
+const LocationsIndexPageMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+    detail_url: z.union([z.string(), z.null()]).optional(),
+    html_url: z.union([z.string(), z.null()]).optional(),
+    locale: z.union([z.string(), z.null()]).optional(),
+    slug: z.string(),
+    first_published_at: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
+    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
+  })
+  .passthrough();
+const LocationsIndexPageSchema = z
+  .object({
+    meta: LocationsIndexPageMetaSchema,
+    id: z.number().int(),
+    title: z.string(),
+    introduction: z.union([z.string(), z.null()]).optional(),
+    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
+  })
+  .passthrough();
+const LocationPageMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+    detail_url: z.union([z.string(), z.null()]).optional(),
+    html_url: z.union([z.string(), z.null()]).optional(),
+    locale: z.union([z.string(), z.null()]).optional(),
+    slug: z.string(),
+    first_published_at: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
+    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
+  })
+  .passthrough();
+const LocationOperatingHoursMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+  })
+  .passthrough();
+const LocationOperatingHoursSchema = z
+  .object({
+    meta: LocationOperatingHoursMetaSchema,
+    id: z.union([z.number(), z.null()]).optional(),
+    day: z.string().max(3).optional().default("MON"),
+    opening_time: z.union([z.string(), z.null()]).optional(),
+    closing_time: z.union([z.string(), z.null()]).optional(),
+    closed: z.union([z.boolean(), z.null()]).optional(),
+    get_day_display: z.unknown().optional(),
+  })
+  .passthrough();
+const LocationPageSchema = z
+  .object({
+    meta: LocationPageMetaSchema,
+    id: z.number().int(),
+    title: z.string(),
+    introduction: z.union([z.string(), z.null()]).optional(),
+    address: z.string(),
+    lat_long: z.string().max(36),
+    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
+    body: z.array(z.unknown()).optional().default([]),
+    is_open: z.unknown().optional(),
+    hours_of_operation: z
+      .array(LocationOperatingHoursSchema)
+      .optional()
+      .default([]),
+    image_hero: z.unknown().optional(),
+    image_location_card: z.unknown().optional(),
+    image_picture_card: z.unknown().optional(),
+  })
+  .passthrough();
+const abc__RecipePageMetaSchema__1 = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+    detail_url: z.union([z.string(), z.null()]).optional(),
+    html_url: z.union([z.string(), z.null()]).optional(),
+    locale: z.union([z.string(), z.null()]).optional(),
+    slug: z.string(),
+    first_published_at: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
+    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
+  })
+  .passthrough();
+const RecipePersonRelationshipMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+  })
+  .passthrough();
+const abc__RecipePageMetaSchema__2 = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+  })
+  .passthrough();
+const RecipePageForeignKeySchema = z
+  .object({
+    meta: abc__RecipePageMetaSchema__2,
+    id: z.union([z.number(), z.null()]).optional(),
+  })
+  .passthrough();
+const RecipePersonRelationshipSchema = z
+  .object({
+    meta: RecipePersonRelationshipMetaSchema,
+    id: z.union([z.number(), z.null()]).optional(),
+    page: RecipePageForeignKeySchema.optional(),
+    person: PersonForeignKeySchema.optional(),
+  })
+  .passthrough();
+const RecipePageSchema = z
+  .object({
+    meta: abc__RecipePageMetaSchema__1,
+    id: z.number().int(),
+    title: z.string(),
+    date_published: z.union([z.string(), z.null()]).optional(),
+    subtitle: z.union([z.string(), z.null()]).optional(),
+    introduction: z.union([z.string(), z.null()]).optional(),
+    backstory: z.array(z.unknown()).optional().default([]),
+    recipe_headline: z.union([z.string(), z.null()]).optional(),
+    body: z.array(z.unknown()).optional().default([]),
+    recipe_person_relationship: z
+      .array(RecipePersonRelationshipSchema)
+      .optional()
+      .default([]),
+  })
+  .passthrough();
+const RecipeIndexPageMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+    detail_url: z.union([z.string(), z.null()]).optional(),
+    html_url: z.union([z.string(), z.null()]).optional(),
+    locale: z.union([z.string(), z.null()]).optional(),
+    slug: z.string(),
+    first_published_at: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
+    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
+  })
+  .passthrough();
+const RecipeIndexPageSchema = z
+  .object({
+    meta: RecipeIndexPageMetaSchema,
+    id: z.number().int(),
+    title: z.string(),
+    introduction: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const PersonPageMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+    detail_url: z.union([z.string(), z.null()]).optional(),
+    html_url: z.union([z.string(), z.null()]).optional(),
+    locale: z.union([z.string(), z.null()]).optional(),
+    slug: z.string(),
+    first_published_at: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
+    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
+  })
+  .passthrough();
+const PersonPageSchema = z
+  .object({
+    meta: PersonPageMetaSchema,
+    id: z.number().int(),
+    title: z.string(),
+    introduction: z.union([z.string(), z.null()]).optional(),
+    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
+    body: z.array(z.unknown()).optional().default([]),
+    location: z.union([CountryForeignKeySchema, z.null()]).optional(),
+    social_links: z.array(z.unknown()).optional().default([]),
+    image_hero: z.unknown().optional(),
+    image_listing: z.unknown().optional(),
+  })
+  .passthrough();
+const PeopleIndexPageMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+    detail_url: z.union([z.string(), z.null()]).optional(),
+    html_url: z.union([z.string(), z.null()]).optional(),
+    locale: z.union([z.string(), z.null()]).optional(),
+    slug: z.string(),
+    first_published_at: z.union([z.string(), z.null()]).optional(),
+    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
+    seo_title: z.union([z.string(), z.null()]).optional(),
+    search_description: z.union([z.string(), z.null()]).optional(),
+    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
+    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
+  })
+  .passthrough();
+const PeopleIndexPageSchema = z
+  .object({
+    meta: PeopleIndexPageMetaSchema,
+    id: z.number().int(),
+    title: z.string(),
+    introduction: z.union([z.string(), z.null()]).optional(),
+    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
+  })
+  .passthrough();
+const version = z
+  .union([z.enum(["live", "draft"]), z.null()])
+  .optional()
+  .default("live");
+const StandardPagePatchMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const StandardPagePatchSchema = z
+  .object({
+    meta: z.union([StandardPagePatchMetaSchema, z.null()]),
+    title: z.union([z.string(), z.null()]),
+    slug: z.union([z.string(), z.null()]),
+    seo_title: z.union([z.string(), z.null()]),
+    search_description: z.union([z.string(), z.null()]),
+    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
+  })
+  .partial()
+  .passthrough();
+const HomePagePatchMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const HomePagePatchSchema = z
+  .object({
+    meta: z.union([HomePagePatchMetaSchema, z.null()]),
+    title: z.union([z.string(), z.null()]),
+    slug: z.union([z.string(), z.null()]),
+    seo_title: z.union([z.string(), z.null()]),
+    search_description: z.union([z.string(), z.null()]),
+    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
+  })
+  .partial()
+  .passthrough();
+const GalleryPagePatchMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const GalleryPagePatchSchema = z
+  .object({
+    meta: z.union([GalleryPagePatchMetaSchema, z.null()]),
+    title: z.union([z.string(), z.null()]),
+    slug: z.union([z.string(), z.null()]),
+    seo_title: z.union([z.string(), z.null()]),
+    search_description: z.union([z.string(), z.null()]),
+    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
+  })
+  .partial()
+  .passthrough();
+const FormPagePatchMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const FormPagePatchSchema = z
+  .object({
+    meta: z.union([FormPagePatchMetaSchema, z.null()]),
+    title: z.union([z.string(), z.null()]),
+    slug: z.union([z.string(), z.null()]),
+    seo_title: z.union([z.string(), z.null()]),
+    search_description: z.union([z.string(), z.null()]),
+    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
+  })
+  .partial()
+  .passthrough();
+const BlogPagePatchMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const BlogPersonRelationshipPatchSchema = z
+  .object({
+    id: z.union([z.number(), z.null()]),
+    page_id: z.union([z.number(), z.null()]),
+    person_id: z.union([z.number(), z.null()]),
+  })
+  .partial()
+  .passthrough();
+const BlogPagePatchSchema = z
+  .object({
+    meta: z.union([BlogPagePatchMetaSchema, z.null()]),
+    title: z.union([z.string(), z.null()]),
+    slug: z.union([z.string(), z.null()]),
+    seo_title: z.union([z.string(), z.null()]),
+    search_description: z.union([z.string(), z.null()]),
+    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
+    introduction: z.union([z.string(), z.null()]),
+    image_id: z.union([z.number(), z.null()]),
+    body: z.array(z.unknown()).default([]),
+    subtitle: z.union([z.string(), z.null()]),
+    date_published: z.union([z.string(), z.null()]),
+    blog_person_relationship: z
+      .array(BlogPersonRelationshipPatchSchema)
+      .default([]),
+  })
+  .partial()
+  .passthrough();
+const BlogIndexPagePatchMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const BlogIndexPagePatchSchema = z
+  .object({
+    meta: z.union([BlogIndexPagePatchMetaSchema, z.null()]),
+    title: z.union([z.string(), z.null()]),
+    slug: z.union([z.string(), z.null()]),
+    seo_title: z.union([z.string(), z.null()]),
+    search_description: z.union([z.string(), z.null()]),
+    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
+    introduction: z.union([z.string(), z.null()]),
+    image_id: z.union([z.number(), z.null()]),
+  })
+  .partial()
+  .passthrough();
+const BreadPagePatchMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const BreadPagePatchSchema = z
+  .object({
+    meta: z.union([BreadPagePatchMetaSchema, z.null()]),
+    title: z.union([z.string(), z.null()]),
+    slug: z.union([z.string(), z.null()]),
+    seo_title: z.union([z.string(), z.null()]),
+    search_description: z.union([z.string(), z.null()]),
+    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
+  })
+  .partial()
+  .passthrough();
+const BreadsIndexPagePatchMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const BreadsIndexPagePatchSchema = z
+  .object({
+    meta: z.union([BreadsIndexPagePatchMetaSchema, z.null()]),
+    title: z.union([z.string(), z.null()]),
+    slug: z.union([z.string(), z.null()]),
+    seo_title: z.union([z.string(), z.null()]),
+    search_description: z.union([z.string(), z.null()]),
+    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
+  })
+  .partial()
+  .passthrough();
+const LocationsIndexPagePatchMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const LocationsIndexPagePatchSchema = z
+  .object({
+    meta: z.union([LocationsIndexPagePatchMetaSchema, z.null()]),
+    title: z.union([z.string(), z.null()]),
+    slug: z.union([z.string(), z.null()]),
+    seo_title: z.union([z.string(), z.null()]),
+    search_description: z.union([z.string(), z.null()]),
+    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
+  })
+  .partial()
+  .passthrough();
+const LocationPagePatchMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const LocationPagePatchSchema = z
+  .object({
+    meta: z.union([LocationPagePatchMetaSchema, z.null()]),
+    title: z.union([z.string(), z.null()]),
+    slug: z.union([z.string(), z.null()]),
+    seo_title: z.union([z.string(), z.null()]),
+    search_description: z.union([z.string(), z.null()]),
+    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
+  })
+  .partial()
+  .passthrough();
+const RecipePagePatchMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const RecipePagePatchSchema = z
+  .object({
+    meta: z.union([RecipePagePatchMetaSchema, z.null()]),
+    title: z.union([z.string(), z.null()]),
+    slug: z.union([z.string(), z.null()]),
+    seo_title: z.union([z.string(), z.null()]),
+    search_description: z.union([z.string(), z.null()]),
+    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
+  })
+  .partial()
+  .passthrough();
+const RecipeIndexPagePatchMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const RecipeIndexPagePatchSchema = z
+  .object({
+    meta: z.union([RecipeIndexPagePatchMetaSchema, z.null()]),
+    title: z.union([z.string(), z.null()]),
+    slug: z.union([z.string(), z.null()]),
+    seo_title: z.union([z.string(), z.null()]),
+    search_description: z.union([z.string(), z.null()]),
+    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
+  })
+  .partial()
+  .passthrough();
+const PersonPagePatchMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const PersonPagePatchSchema = z
+  .object({
+    meta: z.union([PersonPagePatchMetaSchema, z.null()]),
+    title: z.union([z.string(), z.null()]),
+    slug: z.union([z.string(), z.null()]),
+    seo_title: z.union([z.string(), z.null()]),
+    search_description: z.union([z.string(), z.null()]),
+    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
+  })
+  .partial()
+  .passthrough();
+const PeopleIndexPagePatchMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const PeopleIndexPagePatchSchema = z
+  .object({
+    meta: z.union([PeopleIndexPagePatchMetaSchema, z.null()]),
+    title: z.union([z.string(), z.null()]),
+    slug: z.union([z.string(), z.null()]),
+    seo_title: z.union([z.string(), z.null()]),
+    search_description: z.union([z.string(), z.null()]),
+    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
+  })
+  .partial()
+  .passthrough();
+const pages_update_Body = z.union([
+  StandardPagePatchSchema,
+  HomePagePatchSchema,
+  GalleryPagePatchSchema,
+  FormPagePatchSchema,
+  BlogPagePatchSchema,
+  BlogIndexPagePatchSchema,
+  BreadPagePatchSchema,
+  BreadsIndexPagePatchSchema,
+  LocationsIndexPagePatchSchema,
+  LocationPagePatchSchema,
+  RecipePagePatchSchema,
+  RecipeIndexPagePatchSchema,
+  PersonPagePatchSchema,
+  PeopleIndexPagePatchSchema,
+]);
+const BaseMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+  })
+  .passthrough();
+const RevisionSchema = z
+  .object({
+    meta: BaseMetaSchema,
+    id: z.number().int().gt(0),
+    object_id: z.string(),
+    created_at: z.string().datetime({ offset: true }),
+    user_id: z.union([z.number(), z.string(), z.string(), z.null()]).optional(),
+    object_str: z.string(),
+    approved_go_live_at: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const PagedRevisionSchema = z
+  .object({ items: z.array(RevisionSchema), count: z.number().int() })
+  .passthrough();
+const ContentTypeSchema = z
+  .object({
+    meta: BaseMetaSchema,
+    id: z.number().int(),
+    name: z.string(),
+    label: z.string(),
+  })
+  .passthrough();
+const PageRevisionDetailSchema = z
+  .object({
+    meta: BaseMetaSchema,
+    id: z.number().int().gt(0),
+    object_id: z.string(),
+    created_at: z.string().datetime({ offset: true }),
+    user_id: z.union([z.number(), z.string(), z.string(), z.null()]).optional(),
+    object_str: z.string(),
+    approved_go_live_at: z.union([z.string(), z.null()]).optional(),
+    content_type: ContentTypeSchema,
+    base_content_type: ContentTypeSchema,
+    content_object: z.union([
+      PageSchema,
+      StandardPageSchema,
+      HomePageSchema,
+      GalleryPageSchema,
+      FormPageSchema,
+      BlogPageSchema,
+      BlogIndexPageSchema,
+      BreadPageSchema,
+      BreadsIndexPageSchema,
+      LocationsIndexPageSchema,
+      LocationPageSchema,
+      RecipePageSchema,
+      RecipeIndexPageSchema,
+      PersonPageSchema,
+      PeopleIndexPageSchema,
+    ]),
+  })
+  .passthrough();
+const PageUnpublishSchema = z
+  .object({ recursive: z.boolean().default(false) })
+  .partial()
+  .passthrough();
+const pages_actions_unpublish_Body = PageUnpublishSchema;
+const PageCopySchema = z
+  .object({
+    destination_id: z.union([z.number(), z.null()]),
+    recursive: z.boolean().default(false),
+    keep_live: z.boolean().default(true),
+    slug: z.union([z.string(), z.null()]),
+    title: z.union([z.string(), z.null()]),
+  })
+  .partial()
+  .passthrough();
+const pages_actions_copy_Body = PageCopySchema;
+const PageMoveSchema = z
+  .object({
+    destination_id: z.number().int().gt(0),
+    position: z
+      .union([
+        z.enum([
+          "first-child",
+          "last-child",
+          "left",
+          "right",
+          "first-sibling",
+          "last-sibling",
+        ]),
+        z.null(),
+      ])
+      .optional(),
+  })
+  .passthrough();
+const PageRevertSchema = z
+  .object({ revision_id: z.number().int().gt(0) })
+  .passthrough();
+const PageCreateAliasSchema = z
+  .object({
+    destination_id: z.union([z.number(), z.null()]),
+    recursive: z.boolean().default(false),
+    slug: z.union([z.string(), z.null()]),
+  })
+  .partial()
+  .passthrough();
+const pages_actions_create_alias_Body = PageCreateAliasSchema;
+const PageCopyForTranslationSchema = z
+  .object({
+    locale: z.string(),
+    copy_parents: z.boolean().optional().default(false),
+    alias: z.boolean().optional().default(false),
+    recursive: z.boolean().optional().default(false),
+  })
+  .passthrough();
+const ContentTypeSummarySchema = z
+  .object({ name: z.string(), label: z.string() })
+  .passthrough();
+const ContentTypeListSchema = z
+  .object({ types: z.array(ContentTypeSummarySchema) })
+  .passthrough();
+const SchemaDetailResponse = z
+  .object({
+    read: z.union([z.object({}).partial().passthrough(), z.null()]),
+    create: z.union([z.object({}).partial().passthrough(), z.null()]),
+    patch: z.union([z.object({}).partial().passthrough(), z.null()]),
+  })
+  .partial()
+  .passthrough();
+const SiteSchema = z
+  .object({
+    id: z.number().int(),
+    hostname: z.string(),
+    port: z.number().int(),
+    site_name: z.string(),
+    root_page_id: z.number().int(),
+    is_default_site: z.boolean(),
+  })
+  .passthrough();
+const PagedSiteSchema = z
+  .object({ items: z.array(SiteSchema), count: z.number().int() })
+  .passthrough();
+const SiteInputSchema = z
+  .object({
+    hostname: z.string(),
+    port: z.number().int().optional().default(80),
+    site_name: z.string().optional().default(""),
+    root_page_id: z.number().int(),
+    is_default_site: z.boolean().optional().default(false),
+  })
+  .passthrough();
+const WhoAmIUserSchema = z
+  .object({
+    id: z.string(),
+    username: z.string(),
+    email: z.string(),
+    first_name: z.string(),
+    last_name: z.string(),
+    is_superuser: z.boolean(),
+  })
+  .passthrough();
+const WhoAmIProfileSchema = z
+  .object({ avatar_url: z.union([z.string(), z.null()]) })
+  .passthrough();
+const WhoAmISchema = z
+  .object({
+    user: WhoAmIUserSchema,
+    profile: WhoAmIProfileSchema,
+    groups: z.array(z.string()),
+  })
+  .passthrough();
+const BreadIngredientMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+    detail_url: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const BreadIngredientSchema = z
+  .object({
+    meta: BreadIngredientMetaSchema,
+    id: z.union([z.number(), z.null()]).optional(),
+    name: z.string().max(255),
+  })
+  .passthrough();
+const BreadTypeSchema = z
+  .object({
+    meta: BreadTypeMetaSchema,
+    id: z.union([z.number(), z.null()]).optional(),
+    title: z.string().max(255),
+  })
+  .passthrough();
+const FooterTextMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+    detail_url: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const FooterTextSchema = z
+  .object({
+    meta: FooterTextMetaSchema,
+    id: z.union([z.number(), z.null()]).optional(),
+    body: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const PersonSchema = z
+  .object({
+    meta: PersonMetaSchema,
+    id: z.union([z.number(), z.null()]).optional(),
+    first_name: z.string().max(254),
+    last_name: z.string().max(254),
+    job_title: z.string().max(254),
+    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
+    image_avatar: z.unknown().optional(),
+    image_listing: z.unknown().optional(),
+  })
+  .passthrough();
+const PagedAnnotated = z
+  .object({
+    items: z.array(
+      z.union([
+        BreadIngredientSchema,
+        BreadTypeSchema,
+        FooterTextSchema,
+        PersonSchema,
+      ])
+    ),
+    count: z.number().int(),
+  })
+  .passthrough();
+const BreadIngredientCreateMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const BreadIngredientCreateSchema = z
+  .object({ meta: z.union([BreadIngredientCreateMetaSchema, z.null()]) })
+  .partial()
+  .passthrough();
+const BreadTypeCreateMetaSchema = z
+  .object({ type: z.union([z.string(), z.null()]) })
+  .passthrough();
+const BreadTypeCreateSchema = z
+  .object({ meta: z.union([BreadTypeCreateMetaSchema, z.null()]) })
+  .partial()
+  .passthrough();
+const FooterTextCreateMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const FooterTextCreateSchema = z
+  .object({ meta: z.union([FooterTextCreateMetaSchema, z.null()]) })
+  .partial()
+  .passthrough();
+const PersonCreateMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const PersonCreateSchema = z
+  .object({ meta: z.union([PersonCreateMetaSchema, z.null()]) })
+  .partial()
+  .passthrough();
+const snippets_create_Body = z.union([
+  BreadIngredientCreateSchema,
+  BreadTypeCreateSchema,
+  FooterTextCreateSchema,
+  PersonCreateSchema,
+]);
+const BreadIngredientPatchMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const BreadIngredientPatchSchema = z
+  .object({ meta: z.union([BreadIngredientPatchMetaSchema, z.null()]) })
+  .partial()
+  .passthrough();
+const BreadTypePatchMetaSchema = z
+  .object({ type: z.union([z.string(), z.null()]) })
+  .passthrough();
+const BreadTypePatchSchema = z
+  .object({ meta: z.union([BreadTypePatchMetaSchema, z.null()]) })
+  .partial()
+  .passthrough();
+const FooterTextPatchMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const FooterTextPatchSchema = z
+  .object({ meta: z.union([FooterTextPatchMetaSchema, z.null()]) })
+  .partial()
+  .passthrough();
+const PersonPatchMetaSchema = z
+  .object({
+    type: z.union([z.string(), z.null()]),
+    action: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const PersonPatchSchema = z
+  .object({ meta: z.union([PersonPatchMetaSchema, z.null()]) })
+  .partial()
+  .passthrough();
+const snippets_update_Body = z.union([
+  BreadIngredientPatchSchema,
+  BreadTypePatchSchema,
+  FooterTextPatchSchema,
+  PersonPatchSchema,
+]);
+const SnippetRevisionDetailSchema = z
+  .object({
+    meta: BaseMetaSchema,
+    id: z.number().int().gt(0),
+    object_id: z.string(),
+    created_at: z.string().datetime({ offset: true }),
+    user_id: z.union([z.number(), z.string(), z.string(), z.null()]).optional(),
+    object_str: z.string(),
+    approved_go_live_at: z.union([z.string(), z.null()]).optional(),
+    content_type: ContentTypeSchema,
+    base_content_type: ContentTypeSchema,
+    content_object: z.union([
+      BreadIngredientSchema,
+      BreadTypeSchema,
+      FooterTextSchema,
+      PersonSchema,
+    ]),
+  })
+  .passthrough();
+const SnippetRevertSchema = z
+  .object({ revision_id: z.number().int().gt(0) })
+  .passthrough();
+const SnippetCopyForTranslationSchema = z
+  .object({ locale: z.string() })
+  .passthrough();
+const DocumentDetailMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+    detail_url: z.union([z.string(), z.null()]).optional(),
+    tags: z.array(z.string()).optional().default([]),
+    download_url: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const DocumentSchema = z
+  .object({
+    meta: DocumentDetailMetaSchema,
+    id: z.union([z.number(), z.null()]).optional(),
+    title: z.string(),
+    collection: CollectionForeignKeySchema,
+  })
+  .passthrough();
+const PagedDocumentSchema = z
+  .object({ items: z.array(DocumentSchema), count: z.number().int() })
+  .passthrough();
+const documents_create_Body = z
+  .object({
+    file: z.instanceof(File),
+    title: z.string().max(255),
+    collection_id: z.union([z.number(), z.null()]).optional(),
+  })
+  .passthrough();
+const DocumentPatchSchema = z
+  .object({
+    title: z.union([z.string(), z.null()]),
+    collection_id: z.union([z.number(), z.null()]),
+  })
+  .partial()
+  .passthrough();
+const ImageDetailMetaSchema = z
+  .object({
+    type: z.string(),
+    warnings: z
+      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
+      .optional(),
+    detail_url: z.union([z.string(), z.null()]).optional(),
+    tags: z.array(z.string()).optional().default([]),
+    download_url: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+const ImageSchema = z
+  .object({
+    meta: ImageDetailMetaSchema,
+    id: z.union([z.number(), z.null()]).optional(),
+    title: z.string(),
+    width: z.number().int(),
+    height: z.number().int(),
+    description: z.union([z.string(), z.null()]).optional(),
+    collection: CollectionForeignKeySchema.optional(),
+    focal_point_x: z.union([z.number(), z.null()]).optional(),
+    focal_point_y: z.union([z.number(), z.null()]).optional(),
+    focal_point_width: z.union([z.number(), z.null()]).optional(),
+    focal_point_height: z.union([z.number(), z.null()]).optional(),
+  })
+  .passthrough();
+const PagedImageSchema = z
+  .object({ items: z.array(ImageSchema), count: z.number().int() })
+  .passthrough();
+const images_create_Body = z
+  .object({
+    file: z.instanceof(File),
+    title: z.string().max(255),
+    description: z.union([z.string(), z.null()]).optional().default(""),
+    collection_id: z.union([z.number(), z.null()]).optional(),
+    focal_point_x: z.union([z.number(), z.null()]).optional(),
+    focal_point_y: z.union([z.number(), z.null()]).optional(),
+    focal_point_width: z.union([z.number(), z.null()]).optional(),
+    focal_point_height: z.union([z.number(), z.null()]).optional(),
+  })
+  .passthrough();
+const ImagePatchSchema = z
+  .object({
+    title: z.union([z.string(), z.null()]),
+    description: z.union([z.string(), z.null()]).default(""),
+    collection_id: z.union([z.number(), z.null()]),
+    focal_point_x: z.union([z.number(), z.null()]),
+    focal_point_y: z.union([z.number(), z.null()]),
+    focal_point_width: z.union([z.number(), z.null()]),
+    focal_point_height: z.union([z.number(), z.null()]),
+  })
+  .partial()
+  .passthrough();
+const LocaleSchema = z
+  .object({
+    meta: BaseMetaSchema,
+    id: z.number().int().gt(0),
+    language_code: z.string(),
+    display_name: z.string(),
+    is_bidi: z.boolean(),
+    is_default: z.boolean(),
+  })
+  .passthrough();
+const PagedLocaleSchema = z
+  .object({ items: z.array(LocaleSchema), count: z.number().int() })
+  .passthrough();
+const LocaleInputSchema = z.object({ language_code: z.string() }).passthrough();
+const RedirectSchema = z
+  .object({
+    id: z.number().int(),
+    old_path: z.string(),
+    site_id: z.union([z.number(), z.null()]),
+    is_permanent: z.boolean(),
+    redirect_page_id: z.union([z.number(), z.null()]),
+    redirect_page_route_path: z.string(),
+    redirect_link: z.string(),
+    automatically_created: z.boolean(),
+    created_at: z.union([z.string(), z.null()]),
+  })
+  .passthrough();
+const PagedRedirectSchema = z
+  .object({ items: z.array(RedirectSchema), count: z.number().int() })
+  .passthrough();
+const RedirectInputSchema = z
+  .object({
+    old_path: z.string(),
+    site: z.union([z.number(), z.null()]).optional(),
+    is_permanent: z.boolean().optional().default(true),
+    redirect_page_id: z.union([z.number(), z.null()]).optional(),
+    redirect_page_route_path: z.string().optional().default(""),
+    redirect_link: z.string().optional().default(""),
+  })
+  .passthrough();
+const Input = z
+  .object({
+    limit: z.number().int().gte(1).default(20),
+    offset: z.number().int().gte(0).default(0),
+  })
+  .partial()
+  .passthrough();
+const OrderingSchema = z
+  .object({ order: z.union([z.string(), z.array(z.string())]).default([]) })
+  .partial()
+  .passthrough();
+const PageFilterSchema = z
+  .object({
+    type: z
+      .array(
+        z.enum([
+          "wagtailcore.Page",
+          "base.StandardPage",
+          "base.HomePage",
+          "base.GalleryPage",
+          "base.FormPage",
+          "blog.BlogPage",
+          "blog.BlogIndexPage",
+          "breads.BreadPage",
+          "breads.BreadsIndexPage",
+          "locations.LocationsIndexPage",
+          "locations.LocationPage",
+          "recipes.RecipePage",
+          "recipes.RecipeIndexPage",
+          "people.PersonPage",
+          "people.PeopleIndexPage",
+        ])
+      )
+      .default([]),
+    ancestor_of: z.union([z.number(), z.null()]),
+    child_of: z.union([z.number(), z.string(), z.null()]),
+    descendant_of: z.union([z.number(), z.string(), z.null()]),
+    translation_of: z.union([z.number(), z.string(), z.null()]),
+    locale: z.union([z.string(), z.null()]),
+    site: z.union([z.string(), z.null()]),
+  })
+  .partial()
+  .passthrough();
+const SearchSchema = z
+  .object({
+    search: z.union([z.string(), z.null()]),
+    search_operator: z.union([z.enum(["and", "or"]), z.null()]),
+  })
+  .partial()
+  .passthrough();
+const RevisionFilterSchema = z
+  .object({
+    created_at_from: z.union([z.string(), z.null()]),
+    created_at_to: z.union([z.string(), z.null()]),
+    user_id: z.union([z.number(), z.string(), z.null()]),
+    approved_go_live_at_from: z.union([z.string(), z.null()]),
+    approved_go_live_at_to: z.union([z.string(), z.null()]),
+    object_str: z.union([z.string(), z.null()]),
+  })
+  .partial()
+  .passthrough();
+const TranslationFilterSchema = z
+  .object({
+    locale: z.union([z.string(), z.null()]),
+    translation_of: z.union([z.string(), z.null()]),
+  })
+  .partial()
+  .passthrough();
+const DocumentCreateSchema = z
+  .object({
+    title: z.string().max(255),
+    collection_id: z.union([z.number(), z.null()]).optional(),
+  })
+  .passthrough();
+const ImageCreateSchema = z
+  .object({
+    title: z.string().max(255),
+    description: z.union([z.string(), z.null()]).optional().default(""),
+    collection_id: z.union([z.number(), z.null()]).optional(),
+    focal_point_x: z.union([z.number(), z.null()]).optional(),
+    focal_point_y: z.union([z.number(), z.null()]).optional(),
+    focal_point_width: z.union([z.number(), z.null()]).optional(),
+    focal_point_height: z.union([z.number(), z.null()]).optional(),
+  })
+  .passthrough();
+
+export const schemas = {
+  ancestor_of,
+  child_of,
+  locale,
+  order,
+  search_operator,
+  RichTextRemoval,
+  BasePageMetaSchema,
+  BasePageSchema,
+  PagedBasePageSchema,
+  StandardPageCreateMetaSchema,
+  StandardPageCreateSchema,
+  HomePageCreateMetaSchema,
+  HomePageCreateSchema,
+  GalleryPageCreateMetaSchema,
+  GalleryPageCreateSchema,
+  FormPageCreateMetaSchema,
+  FormPageCreateSchema,
+  BlogPageCreateMetaSchema,
+  BlogPersonRelationshipCreateSchema,
+  BlogPageCreateSchema,
+  BlogIndexPageCreateMetaSchema,
+  BlogIndexPageCreateSchema,
+  BreadPageCreateMetaSchema,
+  BreadPageCreateSchema,
+  BreadsIndexPageCreateMetaSchema,
+  BreadsIndexPageCreateSchema,
+  LocationsIndexPageCreateMetaSchema,
+  LocationsIndexPageCreateSchema,
+  LocationPageCreateMetaSchema,
+  LocationPageCreateSchema,
+  RecipePageCreateMetaSchema,
+  RecipePageCreateSchema,
+  RecipeIndexPageCreateMetaSchema,
+  RecipeIndexPageCreateSchema,
+  PersonPageCreateMetaSchema,
+  PersonPageCreateSchema,
+  PeopleIndexPageCreateMetaSchema,
+  PeopleIndexPageCreateSchema,
+  pages_create_Body,
+  rich_text_format,
+  SimpleBasePageMetaSchema,
+  SimpleBasePageSchema,
+  abc__PageMetaSchema__1,
+  PageSchema,
+  StandardPageMetaSchema,
+  ImageMetaSchema,
+  ImageForeignKeySchema,
+  StandardPageSchema,
+  HomePageMetaSchema,
+  abc__PageMetaSchema__2,
+  PageForeignKeySchema,
+  HomePageSchema,
+  GalleryPageMetaSchema,
+  CollectionMetaSchema,
+  CollectionForeignKeySchema,
+  GalleryPageSchema,
+  FormPageMetaSchema,
+  FormFieldMetaSchema,
+  FormFieldSchema,
+  FormPageSchema,
+  abc__BlogPageMetaSchema__1,
+  BlogPersonRelationshipMetaSchema,
+  abc__BlogPageMetaSchema__2,
+  BlogPageForeignKeySchema,
+  PersonMetaSchema,
+  PersonForeignKeySchema,
+  BlogPersonRelationshipSchema,
+  BlogPageSchema,
+  BlogIndexPageMetaSchema,
+  BlogIndexPageSchema,
+  BreadPageMetaSchema,
+  CountryMetaSchema,
+  CountryForeignKeySchema,
+  BreadTypeMetaSchema,
+  BreadTypeForeignKeySchema,
+  BreadPageSchema,
+  BreadsIndexPageMetaSchema,
+  BreadsIndexPageSchema,
+  LocationsIndexPageMetaSchema,
+  LocationsIndexPageSchema,
+  LocationPageMetaSchema,
+  LocationOperatingHoursMetaSchema,
+  LocationOperatingHoursSchema,
+  LocationPageSchema,
+  abc__RecipePageMetaSchema__1,
+  RecipePersonRelationshipMetaSchema,
+  abc__RecipePageMetaSchema__2,
+  RecipePageForeignKeySchema,
+  RecipePersonRelationshipSchema,
+  RecipePageSchema,
+  RecipeIndexPageMetaSchema,
+  RecipeIndexPageSchema,
+  PersonPageMetaSchema,
+  PersonPageSchema,
+  PeopleIndexPageMetaSchema,
+  PeopleIndexPageSchema,
+  version,
+  StandardPagePatchMetaSchema,
+  StandardPagePatchSchema,
+  HomePagePatchMetaSchema,
+  HomePagePatchSchema,
+  GalleryPagePatchMetaSchema,
+  GalleryPagePatchSchema,
+  FormPagePatchMetaSchema,
+  FormPagePatchSchema,
+  BlogPagePatchMetaSchema,
+  BlogPersonRelationshipPatchSchema,
+  BlogPagePatchSchema,
+  BlogIndexPagePatchMetaSchema,
+  BlogIndexPagePatchSchema,
+  BreadPagePatchMetaSchema,
+  BreadPagePatchSchema,
+  BreadsIndexPagePatchMetaSchema,
+  BreadsIndexPagePatchSchema,
+  LocationsIndexPagePatchMetaSchema,
+  LocationsIndexPagePatchSchema,
+  LocationPagePatchMetaSchema,
+  LocationPagePatchSchema,
+  RecipePagePatchMetaSchema,
+  RecipePagePatchSchema,
+  RecipeIndexPagePatchMetaSchema,
+  RecipeIndexPagePatchSchema,
+  PersonPagePatchMetaSchema,
+  PersonPagePatchSchema,
+  PeopleIndexPagePatchMetaSchema,
+  PeopleIndexPagePatchSchema,
+  pages_update_Body,
+  BaseMetaSchema,
+  RevisionSchema,
+  PagedRevisionSchema,
+  ContentTypeSchema,
+  PageRevisionDetailSchema,
+  PageUnpublishSchema,
+  pages_actions_unpublish_Body,
+  PageCopySchema,
+  pages_actions_copy_Body,
+  PageMoveSchema,
+  PageRevertSchema,
+  PageCreateAliasSchema,
+  pages_actions_create_alias_Body,
+  PageCopyForTranslationSchema,
+  ContentTypeSummarySchema,
+  ContentTypeListSchema,
+  SchemaDetailResponse,
+  SiteSchema,
+  PagedSiteSchema,
+  SiteInputSchema,
+  WhoAmIUserSchema,
+  WhoAmIProfileSchema,
+  WhoAmISchema,
+  BreadIngredientMetaSchema,
+  BreadIngredientSchema,
+  BreadTypeSchema,
+  FooterTextMetaSchema,
+  FooterTextSchema,
+  PersonSchema,
+  PagedAnnotated,
+  BreadIngredientCreateMetaSchema,
+  BreadIngredientCreateSchema,
+  BreadTypeCreateMetaSchema,
+  BreadTypeCreateSchema,
+  FooterTextCreateMetaSchema,
+  FooterTextCreateSchema,
+  PersonCreateMetaSchema,
+  PersonCreateSchema,
+  snippets_create_Body,
+  BreadIngredientPatchMetaSchema,
+  BreadIngredientPatchSchema,
+  BreadTypePatchMetaSchema,
+  BreadTypePatchSchema,
+  FooterTextPatchMetaSchema,
+  FooterTextPatchSchema,
+  PersonPatchMetaSchema,
+  PersonPatchSchema,
+  snippets_update_Body,
+  SnippetRevisionDetailSchema,
+  SnippetRevertSchema,
+  SnippetCopyForTranslationSchema,
+  DocumentDetailMetaSchema,
+  DocumentSchema,
+  PagedDocumentSchema,
+  documents_create_Body,
+  DocumentPatchSchema,
+  ImageDetailMetaSchema,
+  ImageSchema,
+  PagedImageSchema,
+  images_create_Body,
+  ImagePatchSchema,
+  LocaleSchema,
+  PagedLocaleSchema,
+  LocaleInputSchema,
+  RedirectSchema,
+  PagedRedirectSchema,
+  RedirectInputSchema,
+  Input,
+  OrderingSchema,
+  PageFilterSchema,
+  SearchSchema,
+  RevisionFilterSchema,
+  TranslationFilterSchema,
+  DocumentCreateSchema,
+  ImageCreateSchema,
+};

--- a/lib/generated/schemas.ts
+++ b/lib/generated/schemas.ts
@@ -1,2025 +1,543 @@
-import { z } from "zod";
 
-const ancestor_of = z.union([z.number(), z.null()]).optional();
-const child_of = z.union([z.number(), z.string(), z.null()]).optional();
-const locale = z.union([z.string(), z.null()]).optional();
-const order = z
-  .union([z.string(), z.array(z.string())])
-  .optional()
-  .default([]);
-const search_operator = z.union([z.enum(["and", "or"]), z.null()]).optional();
-const RichTextRemoval = z
-  .object({
-    tag: z.string(),
-    action: z.enum(["unwrapped", "removed"]),
-    reason: z.enum([
-      "feature_disabled",
-      "unknown_linktype",
-      "unknown_embedtype",
-      "missing_attribute",
-    ]),
-    attribute: z.union([z.string(), z.null()]).optional(),
-    detail: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const BasePageMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]).optional(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-    detail_url: z.union([z.string(), z.null()]).optional(),
-    html_url: z.union([z.string(), z.null()]).optional(),
-    locale: z.union([z.string(), z.null()]).optional(),
-    slug: z.string(),
-    first_published_at: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const BasePageSchema = z
-  .object({ meta: BasePageMetaSchema, id: z.number().int(), title: z.string() })
-  .passthrough();
-const PagedBasePageSchema = z
-  .object({ items: z.array(BasePageSchema), count: z.number().int() })
-  .passthrough();
-const StandardPageCreateMetaSchema = z
-  .object({
-    type: z.string(),
-    parent_id: z.number().int(),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const StandardPageCreateSchema = z
-  .object({
-    meta: StandardPageCreateMetaSchema,
-    title: z.string().max(255),
-    slug: z.union([z.string(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
-  })
-  .passthrough();
-const HomePageCreateMetaSchema = z
-  .object({
-    type: z.string(),
-    parent_id: z.number().int(),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const HomePageCreateSchema = z
-  .object({
-    meta: HomePageCreateMetaSchema,
-    title: z.string().max(255),
-    slug: z.union([z.string(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
-  })
-  .passthrough();
-const GalleryPageCreateMetaSchema = z
-  .object({
-    type: z.string(),
-    parent_id: z.number().int(),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const GalleryPageCreateSchema = z
-  .object({
-    meta: GalleryPageCreateMetaSchema,
-    title: z.string().max(255),
-    slug: z.union([z.string(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
-  })
-  .passthrough();
-const FormPageCreateMetaSchema = z
-  .object({
-    type: z.string(),
-    parent_id: z.number().int(),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const FormPageCreateSchema = z
-  .object({
-    meta: FormPageCreateMetaSchema,
-    title: z.string().max(255),
-    slug: z.union([z.string(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
-  })
-  .passthrough();
-const BlogPageCreateMetaSchema = z
-  .object({
-    type: z.string(),
-    parent_id: z.number().int(),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const BlogPersonRelationshipCreateSchema = z
-  .object({ page_id: z.number().int(), person_id: z.number().int() })
-  .passthrough();
-const BlogPageCreateSchema = z
-  .object({
-    meta: BlogPageCreateMetaSchema,
-    title: z.string().max(255),
-    slug: z.union([z.string(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
-    introduction: z.union([z.string(), z.null()]).optional(),
-    image_id: z.union([z.number(), z.null()]).optional(),
-    body: z.array(z.unknown()).optional().default([]),
-    subtitle: z.union([z.string(), z.null()]).optional(),
-    date_published: z.union([z.string(), z.null()]).optional(),
-    blog_person_relationship: z
-      .array(BlogPersonRelationshipCreateSchema)
-      .optional()
-      .default([]),
-  })
-  .passthrough();
-const BlogIndexPageCreateMetaSchema = z
-  .object({
-    type: z.string(),
-    parent_id: z.number().int(),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const BlogIndexPageCreateSchema = z
-  .object({
-    meta: BlogIndexPageCreateMetaSchema,
-    title: z.string().max(255),
-    slug: z.union([z.string(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
-    introduction: z.union([z.string(), z.null()]).optional(),
-    image_id: z.union([z.number(), z.null()]).optional(),
-  })
-  .passthrough();
-const BreadPageCreateMetaSchema = z
-  .object({
-    type: z.string(),
-    parent_id: z.number().int(),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const BreadPageCreateSchema = z
-  .object({
-    meta: BreadPageCreateMetaSchema,
-    title: z.string().max(255),
-    slug: z.union([z.string(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
-  })
-  .passthrough();
-const BreadsIndexPageCreateMetaSchema = z
-  .object({
-    type: z.string(),
-    parent_id: z.number().int(),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const BreadsIndexPageCreateSchema = z
-  .object({
-    meta: BreadsIndexPageCreateMetaSchema,
-    title: z.string().max(255),
-    slug: z.union([z.string(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
-  })
-  .passthrough();
-const LocationsIndexPageCreateMetaSchema = z
-  .object({
-    type: z.string(),
-    parent_id: z.number().int(),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const LocationsIndexPageCreateSchema = z
-  .object({
-    meta: LocationsIndexPageCreateMetaSchema,
-    title: z.string().max(255),
-    slug: z.union([z.string(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
-  })
-  .passthrough();
-const LocationPageCreateMetaSchema = z
-  .object({
-    type: z.string(),
-    parent_id: z.number().int(),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const LocationPageCreateSchema = z
-  .object({
-    meta: LocationPageCreateMetaSchema,
-    title: z.string().max(255),
-    slug: z.union([z.string(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
-  })
-  .passthrough();
-const RecipePageCreateMetaSchema = z
-  .object({
-    type: z.string(),
-    parent_id: z.number().int(),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const RecipePageCreateSchema = z
-  .object({
-    meta: RecipePageCreateMetaSchema,
-    title: z.string().max(255),
-    slug: z.union([z.string(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
-  })
-  .passthrough();
-const RecipeIndexPageCreateMetaSchema = z
-  .object({
-    type: z.string(),
-    parent_id: z.number().int(),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const RecipeIndexPageCreateSchema = z
-  .object({
-    meta: RecipeIndexPageCreateMetaSchema,
-    title: z.string().max(255),
-    slug: z.union([z.string(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
-  })
-  .passthrough();
-const PersonPageCreateMetaSchema = z
-  .object({
-    type: z.string(),
-    parent_id: z.number().int(),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const PersonPageCreateSchema = z
-  .object({
-    meta: PersonPageCreateMetaSchema,
-    title: z.string().max(255),
-    slug: z.union([z.string(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
-  })
-  .passthrough();
-const PeopleIndexPageCreateMetaSchema = z
-  .object({
-    type: z.string(),
-    parent_id: z.number().int(),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const PeopleIndexPageCreateSchema = z
-  .object({
-    meta: PeopleIndexPageCreateMetaSchema,
-    title: z.string().max(255),
-    slug: z.union([z.string(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional().default(false),
-  })
-  .passthrough();
-const pages_create_Body = z.union([
-  StandardPageCreateSchema,
-  HomePageCreateSchema,
-  GalleryPageCreateSchema,
-  FormPageCreateSchema,
-  BlogPageCreateSchema,
-  BlogIndexPageCreateSchema,
-  BreadPageCreateSchema,
-  BreadsIndexPageCreateSchema,
-  LocationsIndexPageCreateSchema,
-  LocationPageCreateSchema,
-  RecipePageCreateSchema,
-  RecipeIndexPageCreateSchema,
-  PersonPageCreateSchema,
-  PeopleIndexPageCreateSchema,
-]);
-const rich_text_format = z
-  .union([z.enum(["db_html", "html", "db_markdown", "markdown"]), z.null()])
-  .optional();
-const SimpleBasePageMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]),
-    warnings: z.union([
-      z.array(z.union([RichTextRemoval, z.string()])),
-      z.null(),
-    ]),
-    detail_url: z.union([z.string(), z.null()]),
-    html_url: z.union([z.string(), z.null()]),
-  })
-  .partial()
-  .passthrough();
-const SimpleBasePageSchema = z
-  .object({
-    meta: SimpleBasePageMetaSchema,
-    id: z.number().int(),
-    title: z.string(),
-  })
-  .passthrough();
-const abc__PageMetaSchema__1 = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-    detail_url: z.union([z.string(), z.null()]).optional(),
-    html_url: z.union([z.string(), z.null()]).optional(),
-    locale: z.union([z.string(), z.null()]).optional(),
-    slug: z.string(),
-    first_published_at: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
-    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
-  })
-  .passthrough();
-const PageSchema = z
-  .object({
-    meta: abc__PageMetaSchema__1,
-    id: z.union([z.number(), z.null()]).optional(),
-    title: z.string(),
-  })
-  .passthrough();
-const StandardPageMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-    detail_url: z.union([z.string(), z.null()]).optional(),
-    html_url: z.union([z.string(), z.null()]).optional(),
-    locale: z.union([z.string(), z.null()]).optional(),
-    slug: z.string(),
-    first_published_at: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
-    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
-  })
-  .passthrough();
-const ImageMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-  })
-  .passthrough();
-const ImageForeignKeySchema = z
-  .object({
-    meta: ImageMetaSchema,
-    id: z.union([z.number(), z.null()]).optional(),
-  })
-  .passthrough();
-const StandardPageSchema = z
-  .object({
-    meta: StandardPageMetaSchema,
-    id: z.number().int(),
-    title: z.string(),
-    introduction: z.union([z.string(), z.null()]).optional(),
-    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
-    body: z.array(z.unknown()).optional().default([]),
-    image_hero: z.unknown().optional(),
-  })
-  .passthrough();
-const HomePageMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-    detail_url: z.union([z.string(), z.null()]).optional(),
-    html_url: z.union([z.string(), z.null()]).optional(),
-    locale: z.union([z.string(), z.null()]).optional(),
-    slug: z.string(),
-    first_published_at: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
-    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
-  })
-  .passthrough();
-const abc__PageMetaSchema__2 = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-  })
-  .passthrough();
-const PageForeignKeySchema = z
-  .object({
-    meta: abc__PageMetaSchema__2,
-    id: z.union([z.number(), z.null()]).optional(),
-  })
-  .passthrough();
-const HomePageSchema = z
-  .object({
-    meta: HomePageMetaSchema,
-    id: z.number().int(),
-    title: z.string(),
-    hero_text: z.string().max(255),
-    hero_cta: z.string().max(255),
-    lead_title: z.union([z.string(), z.null()]).optional(),
-    featured_section_1_title: z.union([z.string(), z.null()]).optional(),
-    featured_section_2_title: z.union([z.string(), z.null()]).optional(),
-    featured_section_3_title: z.union([z.string(), z.null()]).optional(),
-    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
-    hero_cta_link: z.union([PageForeignKeySchema, z.null()]).optional(),
-    body: z.array(z.unknown()).optional().default([]),
-    lead_image: z.union([ImageForeignKeySchema, z.null()]).optional(),
-    lead_text: z.union([z.string(), z.null()]).optional(),
-    featured_section_1: z.union([PageForeignKeySchema, z.null()]).optional(),
-    featured_section_2: z.union([PageForeignKeySchema, z.null()]).optional(),
-    featured_section_3: z.union([PageForeignKeySchema, z.null()]).optional(),
-    image_hero: z.unknown().optional(),
-    lead_image_promo: z.unknown().optional(),
-  })
-  .passthrough();
-const GalleryPageMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-    detail_url: z.union([z.string(), z.null()]).optional(),
-    html_url: z.union([z.string(), z.null()]).optional(),
-    locale: z.union([z.string(), z.null()]).optional(),
-    slug: z.string(),
-    first_published_at: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
-    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
-  })
-  .passthrough();
-const CollectionMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-  })
-  .passthrough();
-const CollectionForeignKeySchema = z
-  .object({
-    meta: CollectionMetaSchema,
-    id: z.union([z.number(), z.null()]).optional(),
-  })
-  .passthrough();
-const GalleryPageSchema = z
-  .object({
-    meta: GalleryPageMetaSchema,
-    id: z.number().int(),
-    title: z.string(),
-    introduction: z.union([z.string(), z.null()]).optional(),
-    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
-    body: z.array(z.unknown()).optional().default([]),
-    collection: z.union([CollectionForeignKeySchema, z.null()]).optional(),
-    image_hero: z.unknown().optional(),
-  })
-  .passthrough();
-const FormPageMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-    detail_url: z.union([z.string(), z.null()]).optional(),
-    html_url: z.union([z.string(), z.null()]).optional(),
-    locale: z.union([z.string(), z.null()]).optional(),
-    slug: z.string(),
-    first_published_at: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
-    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
-  })
-  .passthrough();
-const FormFieldMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-  })
-  .passthrough();
-const FormFieldSchema = z
-  .object({
-    meta: FormFieldMetaSchema,
-    id: z.union([z.number(), z.null()]).optional(),
-    clean_name: z.union([z.string(), z.null()]).optional().default(""),
-    label: z.string().max(255),
-    field_type: z.string().max(16),
-    help_text: z.union([z.string(), z.null()]).optional(),
-    required: z.boolean().optional().default(true),
-    choices: z.union([z.string(), z.null()]).optional(),
-    default_value: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const FormPageSchema = z
-  .object({
-    meta: FormPageMetaSchema,
-    id: z.number().int(),
-    title: z.string(),
-    from_address: z.union([z.string(), z.null()]).optional(),
-    to_address: z.union([z.string(), z.null()]).optional(),
-    subject: z.union([z.string(), z.null()]).optional(),
-    form_fields: z.array(FormFieldSchema).optional().default([]),
-    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
-    body: z.array(z.unknown()).optional().default([]),
-    thank_you_text: z.union([z.string(), z.null()]).optional(),
-    image_hero: z.unknown().optional(),
-  })
-  .passthrough();
-const abc__BlogPageMetaSchema__1 = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-    detail_url: z.union([z.string(), z.null()]).optional(),
-    html_url: z.union([z.string(), z.null()]).optional(),
-    locale: z.union([z.string(), z.null()]).optional(),
-    slug: z.string(),
-    first_published_at: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
-    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
-  })
-  .passthrough();
-const BlogPersonRelationshipMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-  })
-  .passthrough();
-const abc__BlogPageMetaSchema__2 = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-  })
-  .passthrough();
-const BlogPageForeignKeySchema = z
-  .object({
-    meta: abc__BlogPageMetaSchema__2,
-    id: z.union([z.number(), z.null()]).optional(),
-  })
-  .passthrough();
-const PersonMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-  })
-  .passthrough();
-const PersonForeignKeySchema = z
-  .object({
-    meta: PersonMetaSchema,
-    id: z.union([z.number(), z.null()]).optional(),
-  })
-  .passthrough();
-const BlogPersonRelationshipSchema = z
-  .object({
-    meta: BlogPersonRelationshipMetaSchema,
-    id: z.union([z.number(), z.null()]).optional(),
-    page: BlogPageForeignKeySchema.optional(),
-    person: PersonForeignKeySchema.optional(),
-  })
-  .passthrough();
-const BlogPageSchema = z
-  .object({
-    meta: abc__BlogPageMetaSchema__1,
-    id: z.number().int(),
-    title: z.string(),
-    introduction: z.union([z.string(), z.null()]).optional(),
-    subtitle: z.union([z.string(), z.null()]).optional(),
-    date_published: z.union([z.string(), z.null()]).optional(),
-    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
-    body: z.array(z.unknown()).optional().default([]),
-    tags: z.array(z.string()).optional().default([]),
-    blog_person_relationship: z
-      .array(BlogPersonRelationshipSchema)
-      .optional()
-      .default([]),
-    image_hero: z.unknown().optional(),
-    image_listing: z.unknown().optional(),
-    image_picture_card: z.unknown().optional(),
-  })
-  .passthrough();
-const BlogIndexPageMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-    detail_url: z.union([z.string(), z.null()]).optional(),
-    html_url: z.union([z.string(), z.null()]).optional(),
-    locale: z.union([z.string(), z.null()]).optional(),
-    slug: z.string(),
-    first_published_at: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
-    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
-  })
-  .passthrough();
-const BlogIndexPageSchema = z
-  .object({
-    meta: BlogIndexPageMetaSchema,
-    id: z.number().int(),
-    title: z.string(),
-    introduction: z.union([z.string(), z.null()]).optional(),
-    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
-  })
-  .passthrough();
-const BreadPageMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-    detail_url: z.union([z.string(), z.null()]).optional(),
-    html_url: z.union([z.string(), z.null()]).optional(),
-    locale: z.union([z.string(), z.null()]).optional(),
-    slug: z.string(),
-    first_published_at: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
-    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
-  })
-  .passthrough();
-const CountryMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-  })
-  .passthrough();
-const CountryForeignKeySchema = z
-  .object({
-    meta: CountryMetaSchema,
-    id: z.union([z.number(), z.null()]).optional(),
-  })
-  .passthrough();
-const BreadTypeMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-  })
-  .passthrough();
-const BreadTypeForeignKeySchema = z
-  .object({
-    meta: BreadTypeMetaSchema,
-    id: z.union([z.number(), z.null()]).optional(),
-  })
-  .passthrough();
-const BreadPageSchema = z
-  .object({
-    meta: BreadPageMetaSchema,
-    id: z.number().int(),
-    title: z.string(),
-    introduction: z.union([z.string(), z.null()]).optional(),
-    ingredients: z.array(z.number().int()),
-    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
-    body: z.array(z.unknown()).optional().default([]),
-    origin: z.union([CountryForeignKeySchema, z.null()]).optional(),
-    bread_type: z.union([BreadTypeForeignKeySchema, z.null()]).optional(),
-    image_hero: z.unknown().optional(),
-    image_listing: z.unknown().optional(),
-  })
-  .passthrough();
-const BreadsIndexPageMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-    detail_url: z.union([z.string(), z.null()]).optional(),
-    html_url: z.union([z.string(), z.null()]).optional(),
-    locale: z.union([z.string(), z.null()]).optional(),
-    slug: z.string(),
-    first_published_at: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
-    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
-  })
-  .passthrough();
-const BreadsIndexPageSchema = z
-  .object({
-    meta: BreadsIndexPageMetaSchema,
-    id: z.number().int(),
-    title: z.string(),
-    introduction: z.union([z.string(), z.null()]).optional(),
-    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
-  })
-  .passthrough();
-const LocationsIndexPageMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-    detail_url: z.union([z.string(), z.null()]).optional(),
-    html_url: z.union([z.string(), z.null()]).optional(),
-    locale: z.union([z.string(), z.null()]).optional(),
-    slug: z.string(),
-    first_published_at: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
-    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
-  })
-  .passthrough();
-const LocationsIndexPageSchema = z
-  .object({
-    meta: LocationsIndexPageMetaSchema,
-    id: z.number().int(),
-    title: z.string(),
-    introduction: z.union([z.string(), z.null()]).optional(),
-    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
-  })
-  .passthrough();
-const LocationPageMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-    detail_url: z.union([z.string(), z.null()]).optional(),
-    html_url: z.union([z.string(), z.null()]).optional(),
-    locale: z.union([z.string(), z.null()]).optional(),
-    slug: z.string(),
-    first_published_at: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
-    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
-  })
-  .passthrough();
-const LocationOperatingHoursMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-  })
-  .passthrough();
-const LocationOperatingHoursSchema = z
-  .object({
-    meta: LocationOperatingHoursMetaSchema,
-    id: z.union([z.number(), z.null()]).optional(),
-    day: z.string().max(3).optional().default("MON"),
-    opening_time: z.union([z.string(), z.null()]).optional(),
-    closing_time: z.union([z.string(), z.null()]).optional(),
-    closed: z.union([z.boolean(), z.null()]).optional(),
-    get_day_display: z.unknown().optional(),
-  })
-  .passthrough();
-const LocationPageSchema = z
-  .object({
-    meta: LocationPageMetaSchema,
-    id: z.number().int(),
-    title: z.string(),
-    introduction: z.union([z.string(), z.null()]).optional(),
-    address: z.string(),
-    lat_long: z.string().max(36),
-    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
-    body: z.array(z.unknown()).optional().default([]),
-    is_open: z.unknown().optional(),
-    hours_of_operation: z
-      .array(LocationOperatingHoursSchema)
-      .optional()
-      .default([]),
-    image_hero: z.unknown().optional(),
-    image_location_card: z.unknown().optional(),
-    image_picture_card: z.unknown().optional(),
-  })
-  .passthrough();
-const abc__RecipePageMetaSchema__1 = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-    detail_url: z.union([z.string(), z.null()]).optional(),
-    html_url: z.union([z.string(), z.null()]).optional(),
-    locale: z.union([z.string(), z.null()]).optional(),
-    slug: z.string(),
-    first_published_at: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
-    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
-  })
-  .passthrough();
-const RecipePersonRelationshipMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-  })
-  .passthrough();
-const abc__RecipePageMetaSchema__2 = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-  })
-  .passthrough();
-const RecipePageForeignKeySchema = z
-  .object({
-    meta: abc__RecipePageMetaSchema__2,
-    id: z.union([z.number(), z.null()]).optional(),
-  })
-  .passthrough();
-const RecipePersonRelationshipSchema = z
-  .object({
-    meta: RecipePersonRelationshipMetaSchema,
-    id: z.union([z.number(), z.null()]).optional(),
-    page: RecipePageForeignKeySchema.optional(),
-    person: PersonForeignKeySchema.optional(),
-  })
-  .passthrough();
-const RecipePageSchema = z
-  .object({
-    meta: abc__RecipePageMetaSchema__1,
-    id: z.number().int(),
-    title: z.string(),
-    date_published: z.union([z.string(), z.null()]).optional(),
-    subtitle: z.union([z.string(), z.null()]).optional(),
-    introduction: z.union([z.string(), z.null()]).optional(),
-    backstory: z.array(z.unknown()).optional().default([]),
-    recipe_headline: z.union([z.string(), z.null()]).optional(),
-    body: z.array(z.unknown()).optional().default([]),
-    recipe_person_relationship: z
-      .array(RecipePersonRelationshipSchema)
-      .optional()
-      .default([]),
-  })
-  .passthrough();
-const RecipeIndexPageMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-    detail_url: z.union([z.string(), z.null()]).optional(),
-    html_url: z.union([z.string(), z.null()]).optional(),
-    locale: z.union([z.string(), z.null()]).optional(),
-    slug: z.string(),
-    first_published_at: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
-    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
-  })
-  .passthrough();
-const RecipeIndexPageSchema = z
-  .object({
-    meta: RecipeIndexPageMetaSchema,
-    id: z.number().int(),
-    title: z.string(),
-    introduction: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const PersonPageMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-    detail_url: z.union([z.string(), z.null()]).optional(),
-    html_url: z.union([z.string(), z.null()]).optional(),
-    locale: z.union([z.string(), z.null()]).optional(),
-    slug: z.string(),
-    first_published_at: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
-    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
-  })
-  .passthrough();
-const PersonPageSchema = z
-  .object({
-    meta: PersonPageMetaSchema,
-    id: z.number().int(),
-    title: z.string(),
-    introduction: z.union([z.string(), z.null()]).optional(),
-    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
-    body: z.array(z.unknown()).optional().default([]),
-    location: z.union([CountryForeignKeySchema, z.null()]).optional(),
-    social_links: z.array(z.unknown()).optional().default([]),
-    image_hero: z.unknown().optional(),
-    image_listing: z.unknown().optional(),
-  })
-  .passthrough();
-const PeopleIndexPageMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-    detail_url: z.union([z.string(), z.null()]).optional(),
-    html_url: z.union([z.string(), z.null()]).optional(),
-    locale: z.union([z.string(), z.null()]).optional(),
-    slug: z.string(),
-    first_published_at: z.union([z.string(), z.null()]).optional(),
-    show_in_menus: z.union([z.boolean(), z.null()]).optional(),
-    seo_title: z.union([z.string(), z.null()]).optional(),
-    search_description: z.union([z.string(), z.null()]).optional(),
-    alias_of: z.union([SimpleBasePageSchema, z.null()]).optional(),
-    parent: z.union([SimpleBasePageSchema, z.null()]).optional(),
-  })
-  .passthrough();
-const PeopleIndexPageSchema = z
-  .object({
-    meta: PeopleIndexPageMetaSchema,
-    id: z.number().int(),
-    title: z.string(),
-    introduction: z.union([z.string(), z.null()]).optional(),
-    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
-  })
-  .passthrough();
-const version = z
-  .union([z.enum(["live", "draft"]), z.null()])
-  .optional()
-  .default("live");
-const StandardPagePatchMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const StandardPagePatchSchema = z
-  .object({
-    meta: z.union([StandardPagePatchMetaSchema, z.null()]),
-    title: z.union([z.string(), z.null()]),
-    slug: z.union([z.string(), z.null()]),
-    seo_title: z.union([z.string(), z.null()]),
-    search_description: z.union([z.string(), z.null()]),
-    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
-  })
-  .partial()
-  .passthrough();
-const HomePagePatchMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const HomePagePatchSchema = z
-  .object({
-    meta: z.union([HomePagePatchMetaSchema, z.null()]),
-    title: z.union([z.string(), z.null()]),
-    slug: z.union([z.string(), z.null()]),
-    seo_title: z.union([z.string(), z.null()]),
-    search_description: z.union([z.string(), z.null()]),
-    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
-  })
-  .partial()
-  .passthrough();
-const GalleryPagePatchMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const GalleryPagePatchSchema = z
-  .object({
-    meta: z.union([GalleryPagePatchMetaSchema, z.null()]),
-    title: z.union([z.string(), z.null()]),
-    slug: z.union([z.string(), z.null()]),
-    seo_title: z.union([z.string(), z.null()]),
-    search_description: z.union([z.string(), z.null()]),
-    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
-  })
-  .partial()
-  .passthrough();
-const FormPagePatchMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const FormPagePatchSchema = z
-  .object({
-    meta: z.union([FormPagePatchMetaSchema, z.null()]),
-    title: z.union([z.string(), z.null()]),
-    slug: z.union([z.string(), z.null()]),
-    seo_title: z.union([z.string(), z.null()]),
-    search_description: z.union([z.string(), z.null()]),
-    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
-  })
-  .partial()
-  .passthrough();
-const BlogPagePatchMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const BlogPersonRelationshipPatchSchema = z
-  .object({
-    id: z.union([z.number(), z.null()]),
-    page_id: z.union([z.number(), z.null()]),
-    person_id: z.union([z.number(), z.null()]),
-  })
-  .partial()
-  .passthrough();
-const BlogPagePatchSchema = z
-  .object({
-    meta: z.union([BlogPagePatchMetaSchema, z.null()]),
-    title: z.union([z.string(), z.null()]),
-    slug: z.union([z.string(), z.null()]),
-    seo_title: z.union([z.string(), z.null()]),
-    search_description: z.union([z.string(), z.null()]),
-    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
-    introduction: z.union([z.string(), z.null()]),
-    image_id: z.union([z.number(), z.null()]),
-    body: z.array(z.unknown()).default([]),
-    subtitle: z.union([z.string(), z.null()]),
-    date_published: z.union([z.string(), z.null()]),
-    blog_person_relationship: z
-      .array(BlogPersonRelationshipPatchSchema)
-      .default([]),
-  })
-  .partial()
-  .passthrough();
-const BlogIndexPagePatchMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const BlogIndexPagePatchSchema = z
-  .object({
-    meta: z.union([BlogIndexPagePatchMetaSchema, z.null()]),
-    title: z.union([z.string(), z.null()]),
-    slug: z.union([z.string(), z.null()]),
-    seo_title: z.union([z.string(), z.null()]),
-    search_description: z.union([z.string(), z.null()]),
-    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
-    introduction: z.union([z.string(), z.null()]),
-    image_id: z.union([z.number(), z.null()]),
-  })
-  .partial()
-  .passthrough();
-const BreadPagePatchMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const BreadPagePatchSchema = z
-  .object({
-    meta: z.union([BreadPagePatchMetaSchema, z.null()]),
-    title: z.union([z.string(), z.null()]),
-    slug: z.union([z.string(), z.null()]),
-    seo_title: z.union([z.string(), z.null()]),
-    search_description: z.union([z.string(), z.null()]),
-    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
-  })
-  .partial()
-  .passthrough();
-const BreadsIndexPagePatchMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const BreadsIndexPagePatchSchema = z
-  .object({
-    meta: z.union([BreadsIndexPagePatchMetaSchema, z.null()]),
-    title: z.union([z.string(), z.null()]),
-    slug: z.union([z.string(), z.null()]),
-    seo_title: z.union([z.string(), z.null()]),
-    search_description: z.union([z.string(), z.null()]),
-    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
-  })
-  .partial()
-  .passthrough();
-const LocationsIndexPagePatchMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const LocationsIndexPagePatchSchema = z
-  .object({
-    meta: z.union([LocationsIndexPagePatchMetaSchema, z.null()]),
-    title: z.union([z.string(), z.null()]),
-    slug: z.union([z.string(), z.null()]),
-    seo_title: z.union([z.string(), z.null()]),
-    search_description: z.union([z.string(), z.null()]),
-    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
-  })
-  .partial()
-  .passthrough();
-const LocationPagePatchMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const LocationPagePatchSchema = z
-  .object({
-    meta: z.union([LocationPagePatchMetaSchema, z.null()]),
-    title: z.union([z.string(), z.null()]),
-    slug: z.union([z.string(), z.null()]),
-    seo_title: z.union([z.string(), z.null()]),
-    search_description: z.union([z.string(), z.null()]),
-    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
-  })
-  .partial()
-  .passthrough();
-const RecipePagePatchMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const RecipePagePatchSchema = z
-  .object({
-    meta: z.union([RecipePagePatchMetaSchema, z.null()]),
-    title: z.union([z.string(), z.null()]),
-    slug: z.union([z.string(), z.null()]),
-    seo_title: z.union([z.string(), z.null()]),
-    search_description: z.union([z.string(), z.null()]),
-    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
-  })
-  .partial()
-  .passthrough();
-const RecipeIndexPagePatchMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const RecipeIndexPagePatchSchema = z
-  .object({
-    meta: z.union([RecipeIndexPagePatchMetaSchema, z.null()]),
-    title: z.union([z.string(), z.null()]),
-    slug: z.union([z.string(), z.null()]),
-    seo_title: z.union([z.string(), z.null()]),
-    search_description: z.union([z.string(), z.null()]),
-    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
-  })
-  .partial()
-  .passthrough();
-const PersonPagePatchMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const PersonPagePatchSchema = z
-  .object({
-    meta: z.union([PersonPagePatchMetaSchema, z.null()]),
-    title: z.union([z.string(), z.null()]),
-    slug: z.union([z.string(), z.null()]),
-    seo_title: z.union([z.string(), z.null()]),
-    search_description: z.union([z.string(), z.null()]),
-    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
-  })
-  .partial()
-  .passthrough();
-const PeopleIndexPagePatchMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const PeopleIndexPagePatchSchema = z
-  .object({
-    meta: z.union([PeopleIndexPagePatchMetaSchema, z.null()]),
-    title: z.union([z.string(), z.null()]),
-    slug: z.union([z.string(), z.null()]),
-    seo_title: z.union([z.string(), z.null()]),
-    search_description: z.union([z.string(), z.null()]),
-    show_in_menus: z.union([z.boolean(), z.null()]).default(false),
-  })
-  .partial()
-  .passthrough();
-const pages_update_Body = z.union([
-  StandardPagePatchSchema,
-  HomePagePatchSchema,
-  GalleryPagePatchSchema,
-  FormPagePatchSchema,
-  BlogPagePatchSchema,
-  BlogIndexPagePatchSchema,
-  BreadPagePatchSchema,
-  BreadsIndexPagePatchSchema,
-  LocationsIndexPagePatchSchema,
-  LocationPagePatchSchema,
-  RecipePagePatchSchema,
-  RecipeIndexPagePatchSchema,
-  PersonPagePatchSchema,
-  PeopleIndexPagePatchSchema,
-]);
-const BaseMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-  })
-  .passthrough();
-const RevisionSchema = z
-  .object({
-    meta: BaseMetaSchema,
-    id: z.number().int().gt(0),
-    object_id: z.string(),
-    created_at: z.string().datetime({ offset: true }),
-    user_id: z.union([z.number(), z.string(), z.string(), z.null()]).optional(),
-    object_str: z.string(),
-    approved_go_live_at: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const PagedRevisionSchema = z
-  .object({ items: z.array(RevisionSchema), count: z.number().int() })
-  .passthrough();
-const ContentTypeSchema = z
-  .object({
-    meta: BaseMetaSchema,
-    id: z.number().int(),
-    name: z.string(),
-    label: z.string(),
-  })
-  .passthrough();
-const PageRevisionDetailSchema = z
-  .object({
-    meta: BaseMetaSchema,
-    id: z.number().int().gt(0),
-    object_id: z.string(),
-    created_at: z.string().datetime({ offset: true }),
-    user_id: z.union([z.number(), z.string(), z.string(), z.null()]).optional(),
-    object_str: z.string(),
-    approved_go_live_at: z.union([z.string(), z.null()]).optional(),
-    content_type: ContentTypeSchema,
-    base_content_type: ContentTypeSchema,
-    content_object: z.union([
-      PageSchema,
-      StandardPageSchema,
-      HomePageSchema,
-      GalleryPageSchema,
-      FormPageSchema,
-      BlogPageSchema,
-      BlogIndexPageSchema,
-      BreadPageSchema,
-      BreadsIndexPageSchema,
-      LocationsIndexPageSchema,
-      LocationPageSchema,
-      RecipePageSchema,
-      RecipeIndexPageSchema,
-      PersonPageSchema,
-      PeopleIndexPageSchema,
-    ]),
-  })
-  .passthrough();
-const PageUnpublishSchema = z
-  .object({ recursive: z.boolean().default(false) })
-  .partial()
-  .passthrough();
-const pages_actions_unpublish_Body = PageUnpublishSchema;
-const PageCopySchema = z
-  .object({
-    destination_id: z.union([z.number(), z.null()]),
-    recursive: z.boolean().default(false),
-    keep_live: z.boolean().default(true),
-    slug: z.union([z.string(), z.null()]),
-    title: z.union([z.string(), z.null()]),
-  })
-  .partial()
-  .passthrough();
-const pages_actions_copy_Body = PageCopySchema;
-const PageMoveSchema = z
-  .object({
-    destination_id: z.number().int().gt(0),
-    position: z
-      .union([
-        z.enum([
-          "first-child",
-          "last-child",
-          "left",
-          "right",
-          "first-sibling",
-          "last-sibling",
-        ]),
-        z.null(),
-      ])
-      .optional(),
-  })
-  .passthrough();
-const PageRevertSchema = z
-  .object({ revision_id: z.number().int().gt(0) })
-  .passthrough();
-const PageCreateAliasSchema = z
-  .object({
-    destination_id: z.union([z.number(), z.null()]),
-    recursive: z.boolean().default(false),
-    slug: z.union([z.string(), z.null()]),
-  })
-  .partial()
-  .passthrough();
-const pages_actions_create_alias_Body = PageCreateAliasSchema;
-const PageCopyForTranslationSchema = z
-  .object({
-    locale: z.string(),
-    copy_parents: z.boolean().optional().default(false),
-    alias: z.boolean().optional().default(false),
-    recursive: z.boolean().optional().default(false),
-  })
-  .passthrough();
-const ContentTypeSummarySchema = z
-  .object({ name: z.string(), label: z.string() })
-  .passthrough();
-const ContentTypeListSchema = z
-  .object({ types: z.array(ContentTypeSummarySchema) })
-  .passthrough();
-const SchemaDetailResponse = z
-  .object({
-    read: z.union([z.object({}).partial().passthrough(), z.null()]),
-    create: z.union([z.object({}).partial().passthrough(), z.null()]),
-    patch: z.union([z.object({}).partial().passthrough(), z.null()]),
-  })
-  .partial()
-  .passthrough();
-const SiteSchema = z
-  .object({
-    id: z.number().int(),
-    hostname: z.string(),
-    port: z.number().int(),
-    site_name: z.string(),
-    root_page_id: z.number().int(),
-    is_default_site: z.boolean(),
-  })
-  .passthrough();
-const PagedSiteSchema = z
-  .object({ items: z.array(SiteSchema), count: z.number().int() })
-  .passthrough();
-const SiteInputSchema = z
-  .object({
-    hostname: z.string(),
-    port: z.number().int().optional().default(80),
-    site_name: z.string().optional().default(""),
-    root_page_id: z.number().int(),
-    is_default_site: z.boolean().optional().default(false),
-  })
-  .passthrough();
-const WhoAmIUserSchema = z
-  .object({
-    id: z.string(),
-    username: z.string(),
-    email: z.string(),
-    first_name: z.string(),
-    last_name: z.string(),
-    is_superuser: z.boolean(),
-  })
-  .passthrough();
-const WhoAmIProfileSchema = z
-  .object({ avatar_url: z.union([z.string(), z.null()]) })
-  .passthrough();
-const WhoAmISchema = z
-  .object({
-    user: WhoAmIUserSchema,
-    profile: WhoAmIProfileSchema,
-    groups: z.array(z.string()),
-  })
-  .passthrough();
-const BreadIngredientMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-    detail_url: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const BreadIngredientSchema = z
-  .object({
-    meta: BreadIngredientMetaSchema,
-    id: z.union([z.number(), z.null()]).optional(),
-    name: z.string().max(255),
-  })
-  .passthrough();
-const BreadTypeSchema = z
-  .object({
-    meta: BreadTypeMetaSchema,
-    id: z.union([z.number(), z.null()]).optional(),
-    title: z.string().max(255),
-  })
-  .passthrough();
-const FooterTextMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-    detail_url: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const FooterTextSchema = z
-  .object({
-    meta: FooterTextMetaSchema,
-    id: z.union([z.number(), z.null()]).optional(),
-    body: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const PersonSchema = z
-  .object({
-    meta: PersonMetaSchema,
-    id: z.union([z.number(), z.null()]).optional(),
-    first_name: z.string().max(254),
-    last_name: z.string().max(254),
-    job_title: z.string().max(254),
-    image: z.union([ImageForeignKeySchema, z.null()]).optional(),
-    image_avatar: z.unknown().optional(),
-    image_listing: z.unknown().optional(),
-  })
-  .passthrough();
-const PagedAnnotated = z
-  .object({
-    items: z.array(
-      z.union([
-        BreadIngredientSchema,
-        BreadTypeSchema,
-        FooterTextSchema,
-        PersonSchema,
-      ])
-    ),
-    count: z.number().int(),
-  })
-  .passthrough();
-const BreadIngredientCreateMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const BreadIngredientCreateSchema = z
-  .object({ meta: z.union([BreadIngredientCreateMetaSchema, z.null()]) })
-  .partial()
-  .passthrough();
-const BreadTypeCreateMetaSchema = z
-  .object({ type: z.union([z.string(), z.null()]) })
-  .passthrough();
-const BreadTypeCreateSchema = z
-  .object({ meta: z.union([BreadTypeCreateMetaSchema, z.null()]) })
-  .partial()
-  .passthrough();
-const FooterTextCreateMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const FooterTextCreateSchema = z
-  .object({ meta: z.union([FooterTextCreateMetaSchema, z.null()]) })
-  .partial()
-  .passthrough();
-const PersonCreateMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const PersonCreateSchema = z
-  .object({ meta: z.union([PersonCreateMetaSchema, z.null()]) })
-  .partial()
-  .passthrough();
-const snippets_create_Body = z.union([
-  BreadIngredientCreateSchema,
-  BreadTypeCreateSchema,
-  FooterTextCreateSchema,
-  PersonCreateSchema,
-]);
-const BreadIngredientPatchMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const BreadIngredientPatchSchema = z
-  .object({ meta: z.union([BreadIngredientPatchMetaSchema, z.null()]) })
-  .partial()
-  .passthrough();
-const BreadTypePatchMetaSchema = z
-  .object({ type: z.union([z.string(), z.null()]) })
-  .passthrough();
-const BreadTypePatchSchema = z
-  .object({ meta: z.union([BreadTypePatchMetaSchema, z.null()]) })
-  .partial()
-  .passthrough();
-const FooterTextPatchMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const FooterTextPatchSchema = z
-  .object({ meta: z.union([FooterTextPatchMetaSchema, z.null()]) })
-  .partial()
-  .passthrough();
-const PersonPatchMetaSchema = z
-  .object({
-    type: z.union([z.string(), z.null()]),
-    action: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const PersonPatchSchema = z
-  .object({ meta: z.union([PersonPatchMetaSchema, z.null()]) })
-  .partial()
-  .passthrough();
-const snippets_update_Body = z.union([
-  BreadIngredientPatchSchema,
-  BreadTypePatchSchema,
-  FooterTextPatchSchema,
-  PersonPatchSchema,
-]);
-const SnippetRevisionDetailSchema = z
-  .object({
-    meta: BaseMetaSchema,
-    id: z.number().int().gt(0),
-    object_id: z.string(),
-    created_at: z.string().datetime({ offset: true }),
-    user_id: z.union([z.number(), z.string(), z.string(), z.null()]).optional(),
-    object_str: z.string(),
-    approved_go_live_at: z.union([z.string(), z.null()]).optional(),
-    content_type: ContentTypeSchema,
-    base_content_type: ContentTypeSchema,
-    content_object: z.union([
-      BreadIngredientSchema,
-      BreadTypeSchema,
-      FooterTextSchema,
-      PersonSchema,
-    ]),
-  })
-  .passthrough();
-const SnippetRevertSchema = z
-  .object({ revision_id: z.number().int().gt(0) })
-  .passthrough();
-const SnippetCopyForTranslationSchema = z
-  .object({ locale: z.string() })
-  .passthrough();
-const DocumentDetailMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-    detail_url: z.union([z.string(), z.null()]).optional(),
-    tags: z.array(z.string()).optional().default([]),
-    download_url: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const DocumentSchema = z
-  .object({
-    meta: DocumentDetailMetaSchema,
-    id: z.union([z.number(), z.null()]).optional(),
-    title: z.string(),
-    collection: CollectionForeignKeySchema,
-  })
-  .passthrough();
-const PagedDocumentSchema = z
-  .object({ items: z.array(DocumentSchema), count: z.number().int() })
-  .passthrough();
-const documents_create_Body = z
-  .object({
-    file: z.instanceof(File),
-    title: z.string().max(255),
-    collection_id: z.union([z.number(), z.null()]).optional(),
-  })
-  .passthrough();
-const DocumentPatchSchema = z
-  .object({
-    title: z.union([z.string(), z.null()]),
-    collection_id: z.union([z.number(), z.null()]),
-  })
-  .partial()
-  .passthrough();
-const ImageDetailMetaSchema = z
-  .object({
-    type: z.string(),
-    warnings: z
-      .union([z.array(z.union([RichTextRemoval, z.string()])), z.null()])
-      .optional(),
-    detail_url: z.union([z.string(), z.null()]).optional(),
-    tags: z.array(z.string()).optional().default([]),
-    download_url: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-const ImageSchema = z
-  .object({
-    meta: ImageDetailMetaSchema,
-    id: z.union([z.number(), z.null()]).optional(),
-    title: z.string(),
-    width: z.number().int(),
-    height: z.number().int(),
-    description: z.union([z.string(), z.null()]).optional(),
-    collection: CollectionForeignKeySchema.optional(),
-    focal_point_x: z.union([z.number(), z.null()]).optional(),
-    focal_point_y: z.union([z.number(), z.null()]).optional(),
-    focal_point_width: z.union([z.number(), z.null()]).optional(),
-    focal_point_height: z.union([z.number(), z.null()]).optional(),
-  })
-  .passthrough();
-const PagedImageSchema = z
-  .object({ items: z.array(ImageSchema), count: z.number().int() })
-  .passthrough();
-const images_create_Body = z
-  .object({
-    file: z.instanceof(File),
-    title: z.string().max(255),
-    description: z.union([z.string(), z.null()]).optional().default(""),
-    collection_id: z.union([z.number(), z.null()]).optional(),
-    focal_point_x: z.union([z.number(), z.null()]).optional(),
-    focal_point_y: z.union([z.number(), z.null()]).optional(),
-    focal_point_width: z.union([z.number(), z.null()]).optional(),
-    focal_point_height: z.union([z.number(), z.null()]).optional(),
-  })
-  .passthrough();
-const ImagePatchSchema = z
-  .object({
-    title: z.union([z.string(), z.null()]),
-    description: z.union([z.string(), z.null()]).default(""),
-    collection_id: z.union([z.number(), z.null()]),
-    focal_point_x: z.union([z.number(), z.null()]),
-    focal_point_y: z.union([z.number(), z.null()]),
-    focal_point_width: z.union([z.number(), z.null()]),
-    focal_point_height: z.union([z.number(), z.null()]),
-  })
-  .partial()
-  .passthrough();
-const LocaleSchema = z
-  .object({
-    meta: BaseMetaSchema,
-    id: z.number().int().gt(0),
-    language_code: z.string(),
-    display_name: z.string(),
-    is_bidi: z.boolean(),
-    is_default: z.boolean(),
-  })
-  .passthrough();
-const PagedLocaleSchema = z
-  .object({ items: z.array(LocaleSchema), count: z.number().int() })
-  .passthrough();
-const LocaleInputSchema = z.object({ language_code: z.string() }).passthrough();
-const RedirectSchema = z
-  .object({
-    id: z.number().int(),
-    old_path: z.string(),
-    site_id: z.union([z.number(), z.null()]),
-    is_permanent: z.boolean(),
-    redirect_page_id: z.union([z.number(), z.null()]),
-    redirect_page_route_path: z.string(),
-    redirect_link: z.string(),
-    automatically_created: z.boolean(),
-    created_at: z.union([z.string(), z.null()]),
-  })
-  .passthrough();
-const PagedRedirectSchema = z
-  .object({ items: z.array(RedirectSchema), count: z.number().int() })
-  .passthrough();
-const RedirectInputSchema = z
-  .object({
-    old_path: z.string(),
-    site: z.union([z.number(), z.null()]).optional(),
-    is_permanent: z.boolean().optional().default(true),
-    redirect_page_id: z.union([z.number(), z.null()]).optional(),
-    redirect_page_route_path: z.string().optional().default(""),
-    redirect_link: z.string().optional().default(""),
-  })
-  .passthrough();
-const Input = z
-  .object({
-    limit: z.number().int().gte(1).default(20),
-    offset: z.number().int().gte(0).default(0),
-  })
-  .partial()
-  .passthrough();
-const OrderingSchema = z
-  .object({ order: z.union([z.string(), z.array(z.string())]).default([]) })
-  .partial()
-  .passthrough();
-const PageFilterSchema = z
-  .object({
-    type: z
-      .array(
-        z.enum([
-          "wagtailcore.Page",
-          "base.StandardPage",
-          "base.HomePage",
-          "base.GalleryPage",
-          "base.FormPage",
-          "blog.BlogPage",
-          "blog.BlogIndexPage",
-          "breads.BreadPage",
-          "breads.BreadsIndexPage",
-          "locations.LocationsIndexPage",
-          "locations.LocationPage",
-          "recipes.RecipePage",
-          "recipes.RecipeIndexPage",
-          "people.PersonPage",
-          "people.PeopleIndexPage",
-        ])
-      )
-      .default([]),
-    ancestor_of: z.union([z.number(), z.null()]),
-    child_of: z.union([z.number(), z.string(), z.null()]),
-    descendant_of: z.union([z.number(), z.string(), z.null()]),
-    translation_of: z.union([z.number(), z.string(), z.null()]),
-    locale: z.union([z.string(), z.null()]),
-    site: z.union([z.string(), z.null()]),
-  })
-  .partial()
-  .passthrough();
-const SearchSchema = z
-  .object({
-    search: z.union([z.string(), z.null()]),
-    search_operator: z.union([z.enum(["and", "or"]), z.null()]),
-  })
-  .partial()
-  .passthrough();
-const RevisionFilterSchema = z
-  .object({
-    created_at_from: z.union([z.string(), z.null()]),
-    created_at_to: z.union([z.string(), z.null()]),
-    user_id: z.union([z.number(), z.string(), z.null()]),
-    approved_go_live_at_from: z.union([z.string(), z.null()]),
-    approved_go_live_at_to: z.union([z.string(), z.null()]),
-    object_str: z.union([z.string(), z.null()]),
-  })
-  .partial()
-  .passthrough();
-const TranslationFilterSchema = z
-  .object({
-    locale: z.union([z.string(), z.null()]),
-    translation_of: z.union([z.string(), z.null()]),
-  })
-  .partial()
-  .passthrough();
-const DocumentCreateSchema = z
-  .object({
-    title: z.string().max(255),
-    collection_id: z.union([z.number(), z.null()]).optional(),
-  })
-  .passthrough();
-const ImageCreateSchema = z
-  .object({
-    title: z.string().max(255),
-    description: z.union([z.string(), z.null()]).optional().default(""),
-    collection_id: z.union([z.number(), z.null()]).optional(),
-    focal_point_x: z.union([z.number(), z.null()]).optional(),
-    focal_point_y: z.union([z.number(), z.null()]).optional(),
-    focal_point_width: z.union([z.number(), z.null()]).optional(),
-    focal_point_height: z.union([z.number(), z.null()]).optional(),
-  })
-  .passthrough();
+  import { z } from "zod";
 
-export const schemas = {
-  ancestor_of,
-  child_of,
-  locale,
-  order,
-  search_operator,
-  RichTextRemoval,
-  BasePageMetaSchema,
-  BasePageSchema,
-  PagedBasePageSchema,
-  StandardPageCreateMetaSchema,
-  StandardPageCreateSchema,
-  HomePageCreateMetaSchema,
-  HomePageCreateSchema,
-  GalleryPageCreateMetaSchema,
-  GalleryPageCreateSchema,
-  FormPageCreateMetaSchema,
-  FormPageCreateSchema,
-  BlogPageCreateMetaSchema,
-  BlogPersonRelationshipCreateSchema,
-  BlogPageCreateSchema,
-  BlogIndexPageCreateMetaSchema,
-  BlogIndexPageCreateSchema,
-  BreadPageCreateMetaSchema,
-  BreadPageCreateSchema,
-  BreadsIndexPageCreateMetaSchema,
-  BreadsIndexPageCreateSchema,
-  LocationsIndexPageCreateMetaSchema,
-  LocationsIndexPageCreateSchema,
-  LocationPageCreateMetaSchema,
-  LocationPageCreateSchema,
-  RecipePageCreateMetaSchema,
-  RecipePageCreateSchema,
-  RecipeIndexPageCreateMetaSchema,
-  RecipeIndexPageCreateSchema,
-  PersonPageCreateMetaSchema,
-  PersonPageCreateSchema,
-  PeopleIndexPageCreateMetaSchema,
-  PeopleIndexPageCreateSchema,
-  pages_create_Body,
-  rich_text_format,
-  SimpleBasePageMetaSchema,
-  SimpleBasePageSchema,
-  abc__PageMetaSchema__1,
-  PageSchema,
-  StandardPageMetaSchema,
-  ImageMetaSchema,
-  ImageForeignKeySchema,
-  StandardPageSchema,
-  HomePageMetaSchema,
-  abc__PageMetaSchema__2,
-  PageForeignKeySchema,
-  HomePageSchema,
-  GalleryPageMetaSchema,
-  CollectionMetaSchema,
-  CollectionForeignKeySchema,
-  GalleryPageSchema,
-  FormPageMetaSchema,
-  FormFieldMetaSchema,
-  FormFieldSchema,
-  FormPageSchema,
-  abc__BlogPageMetaSchema__1,
-  BlogPersonRelationshipMetaSchema,
-  abc__BlogPageMetaSchema__2,
-  BlogPageForeignKeySchema,
-  PersonMetaSchema,
-  PersonForeignKeySchema,
-  BlogPersonRelationshipSchema,
-  BlogPageSchema,
-  BlogIndexPageMetaSchema,
-  BlogIndexPageSchema,
-  BreadPageMetaSchema,
-  CountryMetaSchema,
-  CountryForeignKeySchema,
-  BreadTypeMetaSchema,
-  BreadTypeForeignKeySchema,
-  BreadPageSchema,
-  BreadsIndexPageMetaSchema,
-  BreadsIndexPageSchema,
-  LocationsIndexPageMetaSchema,
-  LocationsIndexPageSchema,
-  LocationPageMetaSchema,
-  LocationOperatingHoursMetaSchema,
-  LocationOperatingHoursSchema,
-  LocationPageSchema,
-  abc__RecipePageMetaSchema__1,
-  RecipePersonRelationshipMetaSchema,
-  abc__RecipePageMetaSchema__2,
-  RecipePageForeignKeySchema,
-  RecipePersonRelationshipSchema,
-  RecipePageSchema,
-  RecipeIndexPageMetaSchema,
-  RecipeIndexPageSchema,
-  PersonPageMetaSchema,
-  PersonPageSchema,
-  PeopleIndexPageMetaSchema,
-  PeopleIndexPageSchema,
-  version,
-  StandardPagePatchMetaSchema,
-  StandardPagePatchSchema,
-  HomePagePatchMetaSchema,
-  HomePagePatchSchema,
-  GalleryPagePatchMetaSchema,
-  GalleryPagePatchSchema,
-  FormPagePatchMetaSchema,
-  FormPagePatchSchema,
-  BlogPagePatchMetaSchema,
-  BlogPersonRelationshipPatchSchema,
-  BlogPagePatchSchema,
-  BlogIndexPagePatchMetaSchema,
-  BlogIndexPagePatchSchema,
-  BreadPagePatchMetaSchema,
-  BreadPagePatchSchema,
-  BreadsIndexPagePatchMetaSchema,
-  BreadsIndexPagePatchSchema,
-  LocationsIndexPagePatchMetaSchema,
-  LocationsIndexPagePatchSchema,
-  LocationPagePatchMetaSchema,
-  LocationPagePatchSchema,
-  RecipePagePatchMetaSchema,
-  RecipePagePatchSchema,
-  RecipeIndexPagePatchMetaSchema,
-  RecipeIndexPagePatchSchema,
-  PersonPagePatchMetaSchema,
-  PersonPagePatchSchema,
-  PeopleIndexPagePatchMetaSchema,
-  PeopleIndexPagePatchSchema,
-  pages_update_Body,
-  BaseMetaSchema,
-  RevisionSchema,
-  PagedRevisionSchema,
-  ContentTypeSchema,
-  PageRevisionDetailSchema,
-  PageUnpublishSchema,
-  pages_actions_unpublish_Body,
-  PageCopySchema,
-  pages_actions_copy_Body,
-  PageMoveSchema,
-  PageRevertSchema,
-  PageCreateAliasSchema,
-  pages_actions_create_alias_Body,
-  PageCopyForTranslationSchema,
-  ContentTypeSummarySchema,
-  ContentTypeListSchema,
-  SchemaDetailResponse,
-  SiteSchema,
-  PagedSiteSchema,
-  SiteInputSchema,
-  WhoAmIUserSchema,
-  WhoAmIProfileSchema,
-  WhoAmISchema,
-  BreadIngredientMetaSchema,
-  BreadIngredientSchema,
-  BreadTypeSchema,
-  FooterTextMetaSchema,
-  FooterTextSchema,
-  PersonSchema,
-  PagedAnnotated,
-  BreadIngredientCreateMetaSchema,
-  BreadIngredientCreateSchema,
-  BreadTypeCreateMetaSchema,
-  BreadTypeCreateSchema,
-  FooterTextCreateMetaSchema,
-  FooterTextCreateSchema,
-  PersonCreateMetaSchema,
-  PersonCreateSchema,
-  snippets_create_Body,
-  BreadIngredientPatchMetaSchema,
-  BreadIngredientPatchSchema,
-  BreadTypePatchMetaSchema,
-  BreadTypePatchSchema,
-  FooterTextPatchMetaSchema,
-  FooterTextPatchSchema,
-  PersonPatchMetaSchema,
-  PersonPatchSchema,
-  snippets_update_Body,
-  SnippetRevisionDetailSchema,
-  SnippetRevertSchema,
-  SnippetCopyForTranslationSchema,
-  DocumentDetailMetaSchema,
-  DocumentSchema,
-  PagedDocumentSchema,
-  documents_create_Body,
-  DocumentPatchSchema,
-  ImageDetailMetaSchema,
-  ImageSchema,
-  PagedImageSchema,
-  images_create_Body,
-  ImagePatchSchema,
-  LocaleSchema,
-  PagedLocaleSchema,
-  LocaleInputSchema,
-  RedirectSchema,
-  PagedRedirectSchema,
-  RedirectInputSchema,
-  Input,
-  OrderingSchema,
-  PageFilterSchema,
-  SearchSchema,
-  RevisionFilterSchema,
-  TranslationFilterSchema,
-  DocumentCreateSchema,
-  ImageCreateSchema,
-};
+// <Schemas>
+export type RichTextRemoval = z.infer<typeof RichTextRemoval>;
+export const RichTextRemoval = z.object({ tag: z.string(), action: z.enum(["unwrapped", "removed"]), reason: z.enum(["feature_disabled", "unknown_linktype", "unknown_embedtype", "missing_attribute"]), attribute: z.string().nullable().optional(), detail: z.string().nullable().optional() });
+
+export type BasePageMetaSchema = z.infer<typeof BasePageMetaSchema>;
+export const BasePageMetaSchema = z.object({ type: z.string().nullable().optional(), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional(), detail_url: z.string().nullable().optional(), html_url: z.string().nullable().optional(), locale: z.string().nullable().optional(), slug: z.string(), first_published_at: z.iso.datetime().nullable().optional() });
+
+export type BasePageSchema = z.infer<typeof BasePageSchema>;
+export const BasePageSchema = z.object({ meta: BasePageMetaSchema, id: z.number().int(), title: z.string() });
+
+export type PagedBasePageSchema = z.infer<typeof PagedBasePageSchema>;
+export const PagedBasePageSchema = z.object({ items: z.array(BasePageSchema), count: z.number().int() });
+
+export type SimpleBasePageMetaSchema = z.infer<typeof SimpleBasePageMetaSchema>;
+export const SimpleBasePageMetaSchema = z.object({ type: z.string().nullable(), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable(), detail_url: z.string().nullable(), html_url: z.string().nullable() }).partial();
+
+export type SimpleBasePageSchema = z.infer<typeof SimpleBasePageSchema>;
+export const SimpleBasePageSchema = z.object({ meta: SimpleBasePageMetaSchema, id: z.number().int(), title: z.string() });
+
+export type BlogIndexPageMetaSchema = z.infer<typeof BlogIndexPageMetaSchema>;
+export const BlogIndexPageMetaSchema = z.object({ type: z.literal("blog.BlogIndexPage"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional(), detail_url: z.string().nullable().optional(), html_url: z.string().nullable().optional(), locale: z.string().nullable().optional(), slug: z.string(), first_published_at: z.iso.datetime().nullable().optional(), show_in_menus: z.boolean().nullable().optional(), seo_title: z.string().nullable().optional(), search_description: z.string().nullable().optional(), alias_of: SimpleBasePageSchema.nullable().optional(), parent: SimpleBasePageSchema.nullable().optional() });
+
+export type ImageMetaSchema = z.infer<typeof ImageMetaSchema>;
+export const ImageMetaSchema = z.object({ type: z.literal("wagtailimages.Image"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional() });
+
+export type ImageForeignKeySchema = z.infer<typeof ImageForeignKeySchema>;
+export const ImageForeignKeySchema = z.object({ meta: ImageMetaSchema, id: z.number().int().nullable().optional() });
+
+export type BlogIndexPageSchema = z.infer<typeof BlogIndexPageSchema>;
+export const BlogIndexPageSchema = z.object({ meta: BlogIndexPageMetaSchema, id: z.number().int(), title: z.string(), introduction: z.string().nullable().optional(), image: ImageForeignKeySchema.nullable().optional() });
+
+export type abc__BlogPageMetaSchema__2 = z.infer<typeof abc__BlogPageMetaSchema__2>;
+export const abc__BlogPageMetaSchema__2 = z.object({ type: z.literal("blog.BlogPage"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional() });
+
+export type BlogPageForeignKeySchema = z.infer<typeof BlogPageForeignKeySchema>;
+export const BlogPageForeignKeySchema = z.object({ meta: abc__BlogPageMetaSchema__2, id: z.number().int().nullable().optional() });
+
+export type abc__BlogPageMetaSchema__1 = z.infer<typeof abc__BlogPageMetaSchema__1>;
+export const abc__BlogPageMetaSchema__1 = z.object({ type: z.literal("blog.BlogPage"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional(), detail_url: z.string().nullable().optional(), html_url: z.string().nullable().optional(), locale: z.string().nullable().optional(), slug: z.string(), first_published_at: z.iso.datetime().nullable().optional(), show_in_menus: z.boolean().nullable().optional(), seo_title: z.string().nullable().optional(), search_description: z.string().nullable().optional(), alias_of: SimpleBasePageSchema.nullable().optional(), parent: SimpleBasePageSchema.nullable().optional() });
+
+export type BlogPersonRelationshipMetaSchema = z.infer<typeof BlogPersonRelationshipMetaSchema>;
+export const BlogPersonRelationshipMetaSchema = z.object({ type: z.literal("blog.BlogPersonRelationship"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional() });
+
+export type PersonMetaSchema = z.infer<typeof PersonMetaSchema>;
+export const PersonMetaSchema = z.object({ type: z.literal("base.Person"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional() });
+
+export type PersonForeignKeySchema = z.infer<typeof PersonForeignKeySchema>;
+export const PersonForeignKeySchema = z.object({ meta: PersonMetaSchema, id: z.number().int().nullable().optional() });
+
+export type BlogPersonRelationshipSchema = z.infer<typeof BlogPersonRelationshipSchema>;
+export const BlogPersonRelationshipSchema = z.object({ meta: BlogPersonRelationshipMetaSchema, id: z.number().int().nullable().optional(), page: BlogPageForeignKeySchema.optional(), person: PersonForeignKeySchema.optional() });
+
+export type BlogPageSchema = z.infer<typeof BlogPageSchema>;
+export const BlogPageSchema = z.object({ meta: abc__BlogPageMetaSchema__1, id: z.number().int(), title: z.string(), introduction: z.string().nullable().optional(), subtitle: z.string().max(255).nullable().optional(), date_published: z.iso.date().nullable().optional(), image: ImageForeignKeySchema.nullable().optional(), body: z.array(z.unknown()).default([]), tags: z.array(z.string()).default([]), blog_person_relationship: z.array(BlogPersonRelationshipSchema).default([]), image_hero: z.unknown().optional(), image_listing: z.unknown().optional(), image_picture_card: z.unknown().optional() });
+
+export type BreadPageMetaSchema = z.infer<typeof BreadPageMetaSchema>;
+export const BreadPageMetaSchema = z.object({ type: z.literal("breads.BreadPage"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional(), detail_url: z.string().nullable().optional(), html_url: z.string().nullable().optional(), locale: z.string().nullable().optional(), slug: z.string(), first_published_at: z.iso.datetime().nullable().optional(), show_in_menus: z.boolean().nullable().optional(), seo_title: z.string().nullable().optional(), search_description: z.string().nullable().optional(), alias_of: SimpleBasePageSchema.nullable().optional(), parent: SimpleBasePageSchema.nullable().optional() });
+
+export type CountryMetaSchema = z.infer<typeof CountryMetaSchema>;
+export const CountryMetaSchema = z.object({ type: z.literal("breads.Country"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional() });
+
+export type CountryForeignKeySchema = z.infer<typeof CountryForeignKeySchema>;
+export const CountryForeignKeySchema = z.object({ meta: CountryMetaSchema, id: z.number().int().nullable().optional() });
+
+export type BreadTypeMetaSchema = z.infer<typeof BreadTypeMetaSchema>;
+export const BreadTypeMetaSchema = z.object({ type: z.literal("breads.BreadType"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional() });
+
+export type BreadTypeForeignKeySchema = z.infer<typeof BreadTypeForeignKeySchema>;
+export const BreadTypeForeignKeySchema = z.object({ meta: BreadTypeMetaSchema, id: z.number().int().nullable().optional() });
+
+export type BreadPageSchema = z.infer<typeof BreadPageSchema>;
+export const BreadPageSchema = z.object({ meta: BreadPageMetaSchema, id: z.number().int(), title: z.string(), introduction: z.string().nullable().optional(), ingredients: z.array(z.number().int()), image: ImageForeignKeySchema.nullable().optional(), body: z.array(z.unknown()).default([]), origin: CountryForeignKeySchema.nullable().optional(), bread_type: BreadTypeForeignKeySchema.nullable().optional(), image_hero: z.unknown().optional(), image_listing: z.unknown().optional() });
+
+export type BreadsIndexPageMetaSchema = z.infer<typeof BreadsIndexPageMetaSchema>;
+export const BreadsIndexPageMetaSchema = z.object({ type: z.literal("breads.BreadsIndexPage"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional(), detail_url: z.string().nullable().optional(), html_url: z.string().nullable().optional(), locale: z.string().nullable().optional(), slug: z.string(), first_published_at: z.iso.datetime().nullable().optional(), show_in_menus: z.boolean().nullable().optional(), seo_title: z.string().nullable().optional(), search_description: z.string().nullable().optional(), alias_of: SimpleBasePageSchema.nullable().optional(), parent: SimpleBasePageSchema.nullable().optional() });
+
+export type BreadsIndexPageSchema = z.infer<typeof BreadsIndexPageSchema>;
+export const BreadsIndexPageSchema = z.object({ meta: BreadsIndexPageMetaSchema, id: z.number().int(), title: z.string(), introduction: z.string().nullable().optional(), image: ImageForeignKeySchema.nullable().optional() });
+
+export type CollectionMetaSchema = z.infer<typeof CollectionMetaSchema>;
+export const CollectionMetaSchema = z.object({ type: z.literal("wagtailcore.Collection"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional() });
+
+export type CollectionForeignKeySchema = z.infer<typeof CollectionForeignKeySchema>;
+export const CollectionForeignKeySchema = z.object({ meta: CollectionMetaSchema, id: z.number().int().nullable().optional() });
+
+export type FormFieldMetaSchema = z.infer<typeof FormFieldMetaSchema>;
+export const FormFieldMetaSchema = z.object({ type: z.literal("base.FormField"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional() });
+
+export type FormFieldSchema = z.infer<typeof FormFieldSchema>;
+export const FormFieldSchema = z.object({ meta: FormFieldMetaSchema, id: z.number().int().nullable().optional(), clean_name: z.string().max(255).nullable().default(""), label: z.string().max(255), field_type: z.string().max(16), help_text: z.string().max(255).nullable().optional(), required: z.boolean().default(true), choices: z.string().nullable().optional(), default_value: z.string().nullable().optional() });
+
+export type FormPageMetaSchema = z.infer<typeof FormPageMetaSchema>;
+export const FormPageMetaSchema = z.object({ type: z.literal("base.FormPage"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional(), detail_url: z.string().nullable().optional(), html_url: z.string().nullable().optional(), locale: z.string().nullable().optional(), slug: z.string(), first_published_at: z.iso.datetime().nullable().optional(), show_in_menus: z.boolean().nullable().optional(), seo_title: z.string().nullable().optional(), search_description: z.string().nullable().optional(), alias_of: SimpleBasePageSchema.nullable().optional(), parent: SimpleBasePageSchema.nullable().optional() });
+
+export type FormPageSchema = z.infer<typeof FormPageSchema>;
+export const FormPageSchema = z.object({ meta: FormPageMetaSchema, id: z.number().int(), title: z.string(), from_address: z.string().max(255).nullable().optional(), to_address: z.string().max(255).nullable().optional(), subject: z.string().max(255).nullable().optional(), form_fields: z.array(FormFieldSchema).default([]), image: ImageForeignKeySchema.nullable().optional(), body: z.array(z.unknown()).default([]), thank_you_text: z.string().nullable().optional(), image_hero: z.unknown().optional() });
+
+export type GalleryPageMetaSchema = z.infer<typeof GalleryPageMetaSchema>;
+export const GalleryPageMetaSchema = z.object({ type: z.literal("base.GalleryPage"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional(), detail_url: z.string().nullable().optional(), html_url: z.string().nullable().optional(), locale: z.string().nullable().optional(), slug: z.string(), first_published_at: z.iso.datetime().nullable().optional(), show_in_menus: z.boolean().nullable().optional(), seo_title: z.string().nullable().optional(), search_description: z.string().nullable().optional(), alias_of: SimpleBasePageSchema.nullable().optional(), parent: SimpleBasePageSchema.nullable().optional() });
+
+export type GalleryPageSchema = z.infer<typeof GalleryPageSchema>;
+export const GalleryPageSchema = z.object({ meta: GalleryPageMetaSchema, id: z.number().int(), title: z.string(), introduction: z.string().nullable().optional(), image: ImageForeignKeySchema.nullable().optional(), body: z.array(z.unknown()).default([]), collection: CollectionForeignKeySchema.nullable().optional(), image_hero: z.unknown().optional() });
+
+export type HomePageMetaSchema = z.infer<typeof HomePageMetaSchema>;
+export const HomePageMetaSchema = z.object({ type: z.literal("base.HomePage"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional(), detail_url: z.string().nullable().optional(), html_url: z.string().nullable().optional(), locale: z.string().nullable().optional(), slug: z.string(), first_published_at: z.iso.datetime().nullable().optional(), show_in_menus: z.boolean().nullable().optional(), seo_title: z.string().nullable().optional(), search_description: z.string().nullable().optional(), alias_of: SimpleBasePageSchema.nullable().optional(), parent: SimpleBasePageSchema.nullable().optional() });
+
+export type abc__PageMetaSchema__2 = z.infer<typeof abc__PageMetaSchema__2>;
+export const abc__PageMetaSchema__2 = z.object({ type: z.literal("wagtailcore.Page"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional() });
+
+export type PageForeignKeySchema = z.infer<typeof PageForeignKeySchema>;
+export const PageForeignKeySchema = z.object({ meta: abc__PageMetaSchema__2, id: z.number().int().nullable().optional() });
+
+export type HomePageSchema = z.infer<typeof HomePageSchema>;
+export const HomePageSchema = z.object({ meta: HomePageMetaSchema, id: z.number().int(), title: z.string(), hero_text: z.string().max(255), hero_cta: z.string().max(255), lead_title: z.string().max(255).nullable().optional(), featured_section_1_title: z.string().max(255).nullable().optional(), featured_section_2_title: z.string().max(255).nullable().optional(), featured_section_3_title: z.string().max(255).nullable().optional(), image: ImageForeignKeySchema.nullable().optional(), hero_cta_link: PageForeignKeySchema.nullable().optional(), body: z.array(z.unknown()).default([]), lead_image: ImageForeignKeySchema.nullable().optional(), lead_text: z.string().nullable().optional(), featured_section_1: PageForeignKeySchema.nullable().optional(), featured_section_2: PageForeignKeySchema.nullable().optional(), featured_section_3: PageForeignKeySchema.nullable().optional(), image_hero: z.unknown().optional(), lead_image_promo: z.unknown().optional() });
+
+export type LocationOperatingHoursMetaSchema = z.infer<typeof LocationOperatingHoursMetaSchema>;
+export const LocationOperatingHoursMetaSchema = z.object({ type: z.literal("locations.LocationOperatingHours"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional() });
+
+export type LocationOperatingHoursSchema = z.infer<typeof LocationOperatingHoursSchema>;
+export const LocationOperatingHoursSchema = z.object({ meta: LocationOperatingHoursMetaSchema, id: z.number().int().nullable().optional(), day: z.string().max(3).default("MON"), opening_time: z.iso.time().nullable().optional(), closing_time: z.iso.time().nullable().optional(), closed: z.boolean().nullable().optional(), get_day_display: z.unknown().optional() });
+
+export type LocationPageMetaSchema = z.infer<typeof LocationPageMetaSchema>;
+export const LocationPageMetaSchema = z.object({ type: z.literal("locations.LocationPage"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional(), detail_url: z.string().nullable().optional(), html_url: z.string().nullable().optional(), locale: z.string().nullable().optional(), slug: z.string(), first_published_at: z.iso.datetime().nullable().optional(), show_in_menus: z.boolean().nullable().optional(), seo_title: z.string().nullable().optional(), search_description: z.string().nullable().optional(), alias_of: SimpleBasePageSchema.nullable().optional(), parent: SimpleBasePageSchema.nullable().optional() });
+
+export type LocationPageSchema = z.infer<typeof LocationPageSchema>;
+export const LocationPageSchema = z.object({ meta: LocationPageMetaSchema, id: z.number().int(), title: z.string(), introduction: z.string().nullable().optional(), address: z.string(), lat_long: z.string().max(36), image: ImageForeignKeySchema.nullable().optional(), body: z.array(z.unknown()).default([]), is_open: z.unknown().optional(), hours_of_operation: z.array(LocationOperatingHoursSchema).default([]), image_hero: z.unknown().optional(), image_location_card: z.unknown().optional(), image_picture_card: z.unknown().optional() });
+
+export type LocationsIndexPageMetaSchema = z.infer<typeof LocationsIndexPageMetaSchema>;
+export const LocationsIndexPageMetaSchema = z.object({ type: z.literal("locations.LocationsIndexPage"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional(), detail_url: z.string().nullable().optional(), html_url: z.string().nullable().optional(), locale: z.string().nullable().optional(), slug: z.string(), first_published_at: z.iso.datetime().nullable().optional(), show_in_menus: z.boolean().nullable().optional(), seo_title: z.string().nullable().optional(), search_description: z.string().nullable().optional(), alias_of: SimpleBasePageSchema.nullable().optional(), parent: SimpleBasePageSchema.nullable().optional() });
+
+export type LocationsIndexPageSchema = z.infer<typeof LocationsIndexPageSchema>;
+export const LocationsIndexPageSchema = z.object({ meta: LocationsIndexPageMetaSchema, id: z.number().int(), title: z.string(), introduction: z.string().nullable().optional(), image: ImageForeignKeySchema.nullable().optional() });
+
+export type abc__PageMetaSchema__1 = z.infer<typeof abc__PageMetaSchema__1>;
+export const abc__PageMetaSchema__1 = z.object({ type: z.literal("wagtailcore.Page"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional(), detail_url: z.string().nullable().optional(), html_url: z.string().nullable().optional(), locale: z.string().nullable().optional(), slug: z.string(), first_published_at: z.iso.datetime().nullable().optional(), show_in_menus: z.boolean().nullable().optional(), seo_title: z.string().nullable().optional(), search_description: z.string().nullable().optional(), alias_of: SimpleBasePageSchema.nullable().optional(), parent: SimpleBasePageSchema.nullable().optional() });
+
+export type PageSchema = z.infer<typeof PageSchema>;
+export const PageSchema = z.object({ meta: abc__PageMetaSchema__1, id: z.number().int().nullable().optional(), title: z.string() });
+
+export type PeopleIndexPageMetaSchema = z.infer<typeof PeopleIndexPageMetaSchema>;
+export const PeopleIndexPageMetaSchema = z.object({ type: z.literal("people.PeopleIndexPage"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional(), detail_url: z.string().nullable().optional(), html_url: z.string().nullable().optional(), locale: z.string().nullable().optional(), slug: z.string(), first_published_at: z.iso.datetime().nullable().optional(), show_in_menus: z.boolean().nullable().optional(), seo_title: z.string().nullable().optional(), search_description: z.string().nullable().optional(), alias_of: SimpleBasePageSchema.nullable().optional(), parent: SimpleBasePageSchema.nullable().optional() });
+
+export type PeopleIndexPageSchema = z.infer<typeof PeopleIndexPageSchema>;
+export const PeopleIndexPageSchema = z.object({ meta: PeopleIndexPageMetaSchema, id: z.number().int(), title: z.string(), introduction: z.string().nullable().optional(), image: ImageForeignKeySchema.nullable().optional() });
+
+export type PersonPageMetaSchema = z.infer<typeof PersonPageMetaSchema>;
+export const PersonPageMetaSchema = z.object({ type: z.literal("people.PersonPage"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional(), detail_url: z.string().nullable().optional(), html_url: z.string().nullable().optional(), locale: z.string().nullable().optional(), slug: z.string(), first_published_at: z.iso.datetime().nullable().optional(), show_in_menus: z.boolean().nullable().optional(), seo_title: z.string().nullable().optional(), search_description: z.string().nullable().optional(), alias_of: SimpleBasePageSchema.nullable().optional(), parent: SimpleBasePageSchema.nullable().optional() });
+
+export type PersonPageSchema = z.infer<typeof PersonPageSchema>;
+export const PersonPageSchema = z.object({ meta: PersonPageMetaSchema, id: z.number().int(), title: z.string(), introduction: z.string().nullable().optional(), image: ImageForeignKeySchema.nullable().optional(), body: z.array(z.unknown()).default([]), location: CountryForeignKeySchema.nullable().optional(), social_links: z.array(z.unknown()).default([]), image_hero: z.unknown().optional(), image_listing: z.unknown().optional() });
+
+export type RecipeIndexPageMetaSchema = z.infer<typeof RecipeIndexPageMetaSchema>;
+export const RecipeIndexPageMetaSchema = z.object({ type: z.literal("recipes.RecipeIndexPage"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional(), detail_url: z.string().nullable().optional(), html_url: z.string().nullable().optional(), locale: z.string().nullable().optional(), slug: z.string(), first_published_at: z.iso.datetime().nullable().optional(), show_in_menus: z.boolean().nullable().optional(), seo_title: z.string().nullable().optional(), search_description: z.string().nullable().optional(), alias_of: SimpleBasePageSchema.nullable().optional(), parent: SimpleBasePageSchema.nullable().optional() });
+
+export type RecipeIndexPageSchema = z.infer<typeof RecipeIndexPageSchema>;
+export const RecipeIndexPageSchema = z.object({ meta: RecipeIndexPageMetaSchema, id: z.number().int(), title: z.string(), introduction: z.string().nullable().optional() });
+
+export type abc__RecipePageMetaSchema__2 = z.infer<typeof abc__RecipePageMetaSchema__2>;
+export const abc__RecipePageMetaSchema__2 = z.object({ type: z.literal("recipes.RecipePage"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional() });
+
+export type RecipePageForeignKeySchema = z.infer<typeof RecipePageForeignKeySchema>;
+export const RecipePageForeignKeySchema = z.object({ meta: abc__RecipePageMetaSchema__2, id: z.number().int().nullable().optional() });
+
+export type abc__RecipePageMetaSchema__1 = z.infer<typeof abc__RecipePageMetaSchema__1>;
+export const abc__RecipePageMetaSchema__1 = z.object({ type: z.literal("recipes.RecipePage"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional(), detail_url: z.string().nullable().optional(), html_url: z.string().nullable().optional(), locale: z.string().nullable().optional(), slug: z.string(), first_published_at: z.iso.datetime().nullable().optional(), show_in_menus: z.boolean().nullable().optional(), seo_title: z.string().nullable().optional(), search_description: z.string().nullable().optional(), alias_of: SimpleBasePageSchema.nullable().optional(), parent: SimpleBasePageSchema.nullable().optional() });
+
+export type RecipePersonRelationshipMetaSchema = z.infer<typeof RecipePersonRelationshipMetaSchema>;
+export const RecipePersonRelationshipMetaSchema = z.object({ type: z.literal("recipes.RecipePersonRelationship"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional() });
+
+export type RecipePersonRelationshipSchema = z.infer<typeof RecipePersonRelationshipSchema>;
+export const RecipePersonRelationshipSchema = z.object({ meta: RecipePersonRelationshipMetaSchema, id: z.number().int().nullable().optional(), page: RecipePageForeignKeySchema.optional(), person: PersonForeignKeySchema.optional() });
+
+export type RecipePageSchema = z.infer<typeof RecipePageSchema>;
+export const RecipePageSchema = z.object({ meta: abc__RecipePageMetaSchema__1, id: z.number().int(), title: z.string(), date_published: z.iso.date().nullable().optional(), subtitle: z.string().max(255).nullable().optional(), introduction: z.string().max(500).nullable().optional(), backstory: z.array(z.unknown()).default([]), recipe_headline: z.string().nullable().optional(), body: z.array(z.unknown()).default([]), recipe_person_relationship: z.array(RecipePersonRelationshipSchema).default([]) });
+
+export type StandardPageMetaSchema = z.infer<typeof StandardPageMetaSchema>;
+export const StandardPageMetaSchema = z.object({ type: z.literal("base.StandardPage"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional(), detail_url: z.string().nullable().optional(), html_url: z.string().nullable().optional(), locale: z.string().nullable().optional(), slug: z.string(), first_published_at: z.iso.datetime().nullable().optional(), show_in_menus: z.boolean().nullable().optional(), seo_title: z.string().nullable().optional(), search_description: z.string().nullable().optional(), alias_of: SimpleBasePageSchema.nullable().optional(), parent: SimpleBasePageSchema.nullable().optional() });
+
+export type StandardPageSchema = z.infer<typeof StandardPageSchema>;
+export const StandardPageSchema = z.object({ meta: StandardPageMetaSchema, id: z.number().int(), title: z.string(), introduction: z.string().nullable().optional(), image: ImageForeignKeySchema.nullable().optional(), body: z.array(z.unknown()).default([]), image_hero: z.unknown().optional() });
+
+export type BlogIndexPageCreateMetaSchema = z.infer<typeof BlogIndexPageCreateMetaSchema>;
+export const BlogIndexPageCreateMetaSchema = z.object({ type: z.literal("blog.BlogIndexPage"), parent_id: z.number().int(), action: z.literal("publish").nullable().optional() });
+
+export type BlogIndexPageCreateSchema = z.infer<typeof BlogIndexPageCreateSchema>;
+export const BlogIndexPageCreateSchema = z.object({ meta: BlogIndexPageCreateMetaSchema, title: z.string().max(255), slug: z.string().max(255).nullable().optional(), seo_title: z.string().max(255).nullable().optional(), search_description: z.string().nullable().optional(), show_in_menus: z.boolean().nullable().default(false), introduction: z.string().nullable().optional(), image_id: z.number().int().nullable().optional() });
+
+export type BlogPageCreateMetaSchema = z.infer<typeof BlogPageCreateMetaSchema>;
+export const BlogPageCreateMetaSchema = z.object({ type: z.literal("blog.BlogPage"), parent_id: z.number().int(), action: z.literal("publish").nullable().optional() });
+
+export type BlogPersonRelationshipCreateSchema = z.infer<typeof BlogPersonRelationshipCreateSchema>;
+export const BlogPersonRelationshipCreateSchema = z.object({ page_id: z.number().int(), person_id: z.number().int() });
+
+export type BlogPageCreateSchema = z.infer<typeof BlogPageCreateSchema>;
+export const BlogPageCreateSchema = z.object({ meta: BlogPageCreateMetaSchema, title: z.string().max(255), slug: z.string().max(255).nullable().optional(), seo_title: z.string().max(255).nullable().optional(), search_description: z.string().nullable().optional(), show_in_menus: z.boolean().nullable().default(false), introduction: z.string().nullable().optional(), image_id: z.number().int().nullable().optional(), body: z.array(z.unknown()).default([]), subtitle: z.string().max(255).nullable().optional(), date_published: z.iso.date().nullable().optional(), blog_person_relationship: z.array(BlogPersonRelationshipCreateSchema).default([]) });
+
+export type BreadPageCreateMetaSchema = z.infer<typeof BreadPageCreateMetaSchema>;
+export const BreadPageCreateMetaSchema = z.object({ type: z.literal("breads.BreadPage"), parent_id: z.number().int(), action: z.literal("publish").nullable().optional() });
+
+export type BreadPageCreateSchema = z.infer<typeof BreadPageCreateSchema>;
+export const BreadPageCreateSchema = z.object({ meta: BreadPageCreateMetaSchema, title: z.string().max(255), slug: z.string().max(255).nullable().optional(), seo_title: z.string().max(255).nullable().optional(), search_description: z.string().nullable().optional(), show_in_menus: z.boolean().nullable().default(false) });
+
+export type BreadsIndexPageCreateMetaSchema = z.infer<typeof BreadsIndexPageCreateMetaSchema>;
+export const BreadsIndexPageCreateMetaSchema = z.object({ type: z.literal("breads.BreadsIndexPage"), parent_id: z.number().int(), action: z.literal("publish").nullable().optional() });
+
+export type BreadsIndexPageCreateSchema = z.infer<typeof BreadsIndexPageCreateSchema>;
+export const BreadsIndexPageCreateSchema = z.object({ meta: BreadsIndexPageCreateMetaSchema, title: z.string().max(255), slug: z.string().max(255).nullable().optional(), seo_title: z.string().max(255).nullable().optional(), search_description: z.string().nullable().optional(), show_in_menus: z.boolean().nullable().default(false) });
+
+export type FormPageCreateMetaSchema = z.infer<typeof FormPageCreateMetaSchema>;
+export const FormPageCreateMetaSchema = z.object({ type: z.literal("base.FormPage"), parent_id: z.number().int(), action: z.literal("publish").nullable().optional() });
+
+export type FormPageCreateSchema = z.infer<typeof FormPageCreateSchema>;
+export const FormPageCreateSchema = z.object({ meta: FormPageCreateMetaSchema, title: z.string().max(255), slug: z.string().max(255).nullable().optional(), seo_title: z.string().max(255).nullable().optional(), search_description: z.string().nullable().optional(), show_in_menus: z.boolean().nullable().default(false) });
+
+export type GalleryPageCreateMetaSchema = z.infer<typeof GalleryPageCreateMetaSchema>;
+export const GalleryPageCreateMetaSchema = z.object({ type: z.literal("base.GalleryPage"), parent_id: z.number().int(), action: z.literal("publish").nullable().optional() });
+
+export type GalleryPageCreateSchema = z.infer<typeof GalleryPageCreateSchema>;
+export const GalleryPageCreateSchema = z.object({ meta: GalleryPageCreateMetaSchema, title: z.string().max(255), slug: z.string().max(255).nullable().optional(), seo_title: z.string().max(255).nullable().optional(), search_description: z.string().nullable().optional(), show_in_menus: z.boolean().nullable().default(false) });
+
+export type HomePageCreateMetaSchema = z.infer<typeof HomePageCreateMetaSchema>;
+export const HomePageCreateMetaSchema = z.object({ type: z.literal("base.HomePage"), parent_id: z.number().int(), action: z.literal("publish").nullable().optional() });
+
+export type HomePageCreateSchema = z.infer<typeof HomePageCreateSchema>;
+export const HomePageCreateSchema = z.object({ meta: HomePageCreateMetaSchema, title: z.string().max(255), slug: z.string().max(255).nullable().optional(), seo_title: z.string().max(255).nullable().optional(), search_description: z.string().nullable().optional(), show_in_menus: z.boolean().nullable().default(false) });
+
+export type LocationPageCreateMetaSchema = z.infer<typeof LocationPageCreateMetaSchema>;
+export const LocationPageCreateMetaSchema = z.object({ type: z.literal("locations.LocationPage"), parent_id: z.number().int(), action: z.literal("publish").nullable().optional() });
+
+export type LocationPageCreateSchema = z.infer<typeof LocationPageCreateSchema>;
+export const LocationPageCreateSchema = z.object({ meta: LocationPageCreateMetaSchema, title: z.string().max(255), slug: z.string().max(255).nullable().optional(), seo_title: z.string().max(255).nullable().optional(), search_description: z.string().nullable().optional(), show_in_menus: z.boolean().nullable().default(false) });
+
+export type LocationsIndexPageCreateMetaSchema = z.infer<typeof LocationsIndexPageCreateMetaSchema>;
+export const LocationsIndexPageCreateMetaSchema = z.object({ type: z.literal("locations.LocationsIndexPage"), parent_id: z.number().int(), action: z.literal("publish").nullable().optional() });
+
+export type LocationsIndexPageCreateSchema = z.infer<typeof LocationsIndexPageCreateSchema>;
+export const LocationsIndexPageCreateSchema = z.object({ meta: LocationsIndexPageCreateMetaSchema, title: z.string().max(255), slug: z.string().max(255).nullable().optional(), seo_title: z.string().max(255).nullable().optional(), search_description: z.string().nullable().optional(), show_in_menus: z.boolean().nullable().default(false) });
+
+export type PeopleIndexPageCreateMetaSchema = z.infer<typeof PeopleIndexPageCreateMetaSchema>;
+export const PeopleIndexPageCreateMetaSchema = z.object({ type: z.literal("people.PeopleIndexPage"), parent_id: z.number().int(), action: z.literal("publish").nullable().optional() });
+
+export type PeopleIndexPageCreateSchema = z.infer<typeof PeopleIndexPageCreateSchema>;
+export const PeopleIndexPageCreateSchema = z.object({ meta: PeopleIndexPageCreateMetaSchema, title: z.string().max(255), slug: z.string().max(255).nullable().optional(), seo_title: z.string().max(255).nullable().optional(), search_description: z.string().nullable().optional(), show_in_menus: z.boolean().nullable().default(false) });
+
+export type PersonPageCreateMetaSchema = z.infer<typeof PersonPageCreateMetaSchema>;
+export const PersonPageCreateMetaSchema = z.object({ type: z.literal("people.PersonPage"), parent_id: z.number().int(), action: z.literal("publish").nullable().optional() });
+
+export type PersonPageCreateSchema = z.infer<typeof PersonPageCreateSchema>;
+export const PersonPageCreateSchema = z.object({ meta: PersonPageCreateMetaSchema, title: z.string().max(255), slug: z.string().max(255).nullable().optional(), seo_title: z.string().max(255).nullable().optional(), search_description: z.string().nullable().optional(), show_in_menus: z.boolean().nullable().default(false) });
+
+export type RecipeIndexPageCreateMetaSchema = z.infer<typeof RecipeIndexPageCreateMetaSchema>;
+export const RecipeIndexPageCreateMetaSchema = z.object({ type: z.literal("recipes.RecipeIndexPage"), parent_id: z.number().int(), action: z.literal("publish").nullable().optional() });
+
+export type RecipeIndexPageCreateSchema = z.infer<typeof RecipeIndexPageCreateSchema>;
+export const RecipeIndexPageCreateSchema = z.object({ meta: RecipeIndexPageCreateMetaSchema, title: z.string().max(255), slug: z.string().max(255).nullable().optional(), seo_title: z.string().max(255).nullable().optional(), search_description: z.string().nullable().optional(), show_in_menus: z.boolean().nullable().default(false) });
+
+export type RecipePageCreateMetaSchema = z.infer<typeof RecipePageCreateMetaSchema>;
+export const RecipePageCreateMetaSchema = z.object({ type: z.literal("recipes.RecipePage"), parent_id: z.number().int(), action: z.literal("publish").nullable().optional() });
+
+export type RecipePageCreateSchema = z.infer<typeof RecipePageCreateSchema>;
+export const RecipePageCreateSchema = z.object({ meta: RecipePageCreateMetaSchema, title: z.string().max(255), slug: z.string().max(255).nullable().optional(), seo_title: z.string().max(255).nullable().optional(), search_description: z.string().nullable().optional(), show_in_menus: z.boolean().nullable().default(false) });
+
+export type StandardPageCreateMetaSchema = z.infer<typeof StandardPageCreateMetaSchema>;
+export const StandardPageCreateMetaSchema = z.object({ type: z.literal("base.StandardPage"), parent_id: z.number().int(), action: z.literal("publish").nullable().optional() });
+
+export type StandardPageCreateSchema = z.infer<typeof StandardPageCreateSchema>;
+export const StandardPageCreateSchema = z.object({ meta: StandardPageCreateMetaSchema, title: z.string().max(255), slug: z.string().max(255).nullable().optional(), seo_title: z.string().max(255).nullable().optional(), search_description: z.string().nullable().optional(), show_in_menus: z.boolean().nullable().default(false) });
+
+export type BlogIndexPagePatchMetaSchema = z.infer<typeof BlogIndexPagePatchMetaSchema>;
+export const BlogIndexPagePatchMetaSchema = z.object({ type: z.literal("blog.BlogIndexPage").nullable(), action: z.literal("publish").nullable().optional() });
+
+export type BlogIndexPagePatchSchema = z.infer<typeof BlogIndexPagePatchSchema>;
+export const BlogIndexPagePatchSchema = z.object({ meta: BlogIndexPagePatchMetaSchema.nullable(), title: z.string().max(255).nullable(), slug: z.string().max(255).nullable(), seo_title: z.string().max(255).nullable(), search_description: z.string().nullable(), show_in_menus: z.boolean().nullable().default(false), introduction: z.string().nullable(), image_id: z.number().int().nullable() }).partial();
+
+export type BlogPagePatchMetaSchema = z.infer<typeof BlogPagePatchMetaSchema>;
+export const BlogPagePatchMetaSchema = z.object({ type: z.literal("blog.BlogPage").nullable(), action: z.literal("publish").nullable().optional() });
+
+export type BlogPersonRelationshipPatchSchema = z.infer<typeof BlogPersonRelationshipPatchSchema>;
+export const BlogPersonRelationshipPatchSchema = z.object({ id: z.number().int().nullable(), page_id: z.number().int().nullable(), person_id: z.number().int().nullable() }).partial();
+
+export type BlogPagePatchSchema = z.infer<typeof BlogPagePatchSchema>;
+export const BlogPagePatchSchema = z.object({ meta: BlogPagePatchMetaSchema.nullable(), title: z.string().max(255).nullable(), slug: z.string().max(255).nullable(), seo_title: z.string().max(255).nullable(), search_description: z.string().nullable(), show_in_menus: z.boolean().nullable().default(false), introduction: z.string().nullable(), image_id: z.number().int().nullable(), body: z.array(z.unknown()).default([]), subtitle: z.string().max(255).nullable(), date_published: z.iso.date().nullable(), blog_person_relationship: z.array(BlogPersonRelationshipPatchSchema).default([]) }).partial();
+
+export type BreadPagePatchMetaSchema = z.infer<typeof BreadPagePatchMetaSchema>;
+export const BreadPagePatchMetaSchema = z.object({ type: z.literal("breads.BreadPage").nullable(), action: z.literal("publish").nullable().optional() });
+
+export type BreadPagePatchSchema = z.infer<typeof BreadPagePatchSchema>;
+export const BreadPagePatchSchema = z.object({ meta: BreadPagePatchMetaSchema.nullable(), title: z.string().max(255).nullable(), slug: z.string().max(255).nullable(), seo_title: z.string().max(255).nullable(), search_description: z.string().nullable(), show_in_menus: z.boolean().nullable().default(false) }).partial();
+
+export type BreadsIndexPagePatchMetaSchema = z.infer<typeof BreadsIndexPagePatchMetaSchema>;
+export const BreadsIndexPagePatchMetaSchema = z.object({ type: z.literal("breads.BreadsIndexPage").nullable(), action: z.literal("publish").nullable().optional() });
+
+export type BreadsIndexPagePatchSchema = z.infer<typeof BreadsIndexPagePatchSchema>;
+export const BreadsIndexPagePatchSchema = z.object({ meta: BreadsIndexPagePatchMetaSchema.nullable(), title: z.string().max(255).nullable(), slug: z.string().max(255).nullable(), seo_title: z.string().max(255).nullable(), search_description: z.string().nullable(), show_in_menus: z.boolean().nullable().default(false) }).partial();
+
+export type FormPagePatchMetaSchema = z.infer<typeof FormPagePatchMetaSchema>;
+export const FormPagePatchMetaSchema = z.object({ type: z.literal("base.FormPage").nullable(), action: z.literal("publish").nullable().optional() });
+
+export type FormPagePatchSchema = z.infer<typeof FormPagePatchSchema>;
+export const FormPagePatchSchema = z.object({ meta: FormPagePatchMetaSchema.nullable(), title: z.string().max(255).nullable(), slug: z.string().max(255).nullable(), seo_title: z.string().max(255).nullable(), search_description: z.string().nullable(), show_in_menus: z.boolean().nullable().default(false) }).partial();
+
+export type GalleryPagePatchMetaSchema = z.infer<typeof GalleryPagePatchMetaSchema>;
+export const GalleryPagePatchMetaSchema = z.object({ type: z.literal("base.GalleryPage").nullable(), action: z.literal("publish").nullable().optional() });
+
+export type GalleryPagePatchSchema = z.infer<typeof GalleryPagePatchSchema>;
+export const GalleryPagePatchSchema = z.object({ meta: GalleryPagePatchMetaSchema.nullable(), title: z.string().max(255).nullable(), slug: z.string().max(255).nullable(), seo_title: z.string().max(255).nullable(), search_description: z.string().nullable(), show_in_menus: z.boolean().nullable().default(false) }).partial();
+
+export type HomePagePatchMetaSchema = z.infer<typeof HomePagePatchMetaSchema>;
+export const HomePagePatchMetaSchema = z.object({ type: z.literal("base.HomePage").nullable(), action: z.literal("publish").nullable().optional() });
+
+export type HomePagePatchSchema = z.infer<typeof HomePagePatchSchema>;
+export const HomePagePatchSchema = z.object({ meta: HomePagePatchMetaSchema.nullable(), title: z.string().max(255).nullable(), slug: z.string().max(255).nullable(), seo_title: z.string().max(255).nullable(), search_description: z.string().nullable(), show_in_menus: z.boolean().nullable().default(false) }).partial();
+
+export type LocationPagePatchMetaSchema = z.infer<typeof LocationPagePatchMetaSchema>;
+export const LocationPagePatchMetaSchema = z.object({ type: z.literal("locations.LocationPage").nullable(), action: z.literal("publish").nullable().optional() });
+
+export type LocationPagePatchSchema = z.infer<typeof LocationPagePatchSchema>;
+export const LocationPagePatchSchema = z.object({ meta: LocationPagePatchMetaSchema.nullable(), title: z.string().max(255).nullable(), slug: z.string().max(255).nullable(), seo_title: z.string().max(255).nullable(), search_description: z.string().nullable(), show_in_menus: z.boolean().nullable().default(false) }).partial();
+
+export type LocationsIndexPagePatchMetaSchema = z.infer<typeof LocationsIndexPagePatchMetaSchema>;
+export const LocationsIndexPagePatchMetaSchema = z.object({ type: z.literal("locations.LocationsIndexPage").nullable(), action: z.literal("publish").nullable().optional() });
+
+export type LocationsIndexPagePatchSchema = z.infer<typeof LocationsIndexPagePatchSchema>;
+export const LocationsIndexPagePatchSchema = z.object({ meta: LocationsIndexPagePatchMetaSchema.nullable(), title: z.string().max(255).nullable(), slug: z.string().max(255).nullable(), seo_title: z.string().max(255).nullable(), search_description: z.string().nullable(), show_in_menus: z.boolean().nullable().default(false) }).partial();
+
+export type PeopleIndexPagePatchMetaSchema = z.infer<typeof PeopleIndexPagePatchMetaSchema>;
+export const PeopleIndexPagePatchMetaSchema = z.object({ type: z.literal("people.PeopleIndexPage").nullable(), action: z.literal("publish").nullable().optional() });
+
+export type PeopleIndexPagePatchSchema = z.infer<typeof PeopleIndexPagePatchSchema>;
+export const PeopleIndexPagePatchSchema = z.object({ meta: PeopleIndexPagePatchMetaSchema.nullable(), title: z.string().max(255).nullable(), slug: z.string().max(255).nullable(), seo_title: z.string().max(255).nullable(), search_description: z.string().nullable(), show_in_menus: z.boolean().nullable().default(false) }).partial();
+
+export type PersonPagePatchMetaSchema = z.infer<typeof PersonPagePatchMetaSchema>;
+export const PersonPagePatchMetaSchema = z.object({ type: z.literal("people.PersonPage").nullable(), action: z.literal("publish").nullable().optional() });
+
+export type PersonPagePatchSchema = z.infer<typeof PersonPagePatchSchema>;
+export const PersonPagePatchSchema = z.object({ meta: PersonPagePatchMetaSchema.nullable(), title: z.string().max(255).nullable(), slug: z.string().max(255).nullable(), seo_title: z.string().max(255).nullable(), search_description: z.string().nullable(), show_in_menus: z.boolean().nullable().default(false) }).partial();
+
+export type RecipeIndexPagePatchMetaSchema = z.infer<typeof RecipeIndexPagePatchMetaSchema>;
+export const RecipeIndexPagePatchMetaSchema = z.object({ type: z.literal("recipes.RecipeIndexPage").nullable(), action: z.literal("publish").nullable().optional() });
+
+export type RecipeIndexPagePatchSchema = z.infer<typeof RecipeIndexPagePatchSchema>;
+export const RecipeIndexPagePatchSchema = z.object({ meta: RecipeIndexPagePatchMetaSchema.nullable(), title: z.string().max(255).nullable(), slug: z.string().max(255).nullable(), seo_title: z.string().max(255).nullable(), search_description: z.string().nullable(), show_in_menus: z.boolean().nullable().default(false) }).partial();
+
+export type RecipePagePatchMetaSchema = z.infer<typeof RecipePagePatchMetaSchema>;
+export const RecipePagePatchMetaSchema = z.object({ type: z.literal("recipes.RecipePage").nullable(), action: z.literal("publish").nullable().optional() });
+
+export type RecipePagePatchSchema = z.infer<typeof RecipePagePatchSchema>;
+export const RecipePagePatchSchema = z.object({ meta: RecipePagePatchMetaSchema.nullable(), title: z.string().max(255).nullable(), slug: z.string().max(255).nullable(), seo_title: z.string().max(255).nullable(), search_description: z.string().nullable(), show_in_menus: z.boolean().nullable().default(false) }).partial();
+
+export type StandardPagePatchMetaSchema = z.infer<typeof StandardPagePatchMetaSchema>;
+export const StandardPagePatchMetaSchema = z.object({ type: z.literal("base.StandardPage").nullable(), action: z.literal("publish").nullable().optional() });
+
+export type StandardPagePatchSchema = z.infer<typeof StandardPagePatchSchema>;
+export const StandardPagePatchSchema = z.object({ meta: StandardPagePatchMetaSchema.nullable(), title: z.string().max(255).nullable(), slug: z.string().max(255).nullable(), seo_title: z.string().max(255).nullable(), search_description: z.string().nullable(), show_in_menus: z.boolean().nullable().default(false) }).partial();
+
+export type BaseMetaSchema = z.infer<typeof BaseMetaSchema>;
+export const BaseMetaSchema = z.object({ type: z.string(), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional() });
+
+export type RevisionSchema = z.infer<typeof RevisionSchema>;
+export const RevisionSchema = z.object({ meta: BaseMetaSchema, id: z.number().int().gt(0), object_id: z.string(), created_at: z.iso.datetime(), user_id: z.union([z.number().int(), z.string(), z.uuid(), z.null()]).optional(), object_str: z.string(), approved_go_live_at: z.iso.datetime().nullable().optional() });
+
+export type PagedRevisionSchema = z.infer<typeof PagedRevisionSchema>;
+export const PagedRevisionSchema = z.object({ items: z.array(RevisionSchema), count: z.number().int() });
+
+export type ContentTypeSchema = z.infer<typeof ContentTypeSchema>;
+export const ContentTypeSchema = z.object({ meta: BaseMetaSchema, id: z.number().int(), name: z.string(), label: z.string() });
+
+export type PageRevisionDetailSchema = z.infer<typeof PageRevisionDetailSchema>;
+export const PageRevisionDetailSchema = z.object({ meta: BaseMetaSchema, id: z.number().int().gt(0), object_id: z.string(), created_at: z.iso.datetime(), user_id: z.union([z.number().int(), z.string(), z.uuid(), z.null()]).optional(), object_str: z.string(), approved_go_live_at: z.iso.datetime().nullable().optional(), content_type: ContentTypeSchema, base_content_type: ContentTypeSchema, content_object: z.union([PageSchema, StandardPageSchema, HomePageSchema, GalleryPageSchema, FormPageSchema, BlogPageSchema, BlogIndexPageSchema, BreadPageSchema, BreadsIndexPageSchema, LocationsIndexPageSchema, LocationPageSchema, RecipePageSchema, RecipeIndexPageSchema, PersonPageSchema, PeopleIndexPageSchema]) });
+
+export type PageUnpublishSchema = z.infer<typeof PageUnpublishSchema>;
+export const PageUnpublishSchema = z.object({ recursive: z.boolean().default(false) }).partial();
+
+export type PageCopySchema = z.infer<typeof PageCopySchema>;
+export const PageCopySchema = z.object({ destination_id: z.number().int().gt(0).nullable(), recursive: z.boolean().default(false), keep_live: z.boolean().default(true), slug: z.string().nullable(), title: z.string().nullable() }).partial();
+
+export type PageMoveSchema = z.infer<typeof PageMoveSchema>;
+export const PageMoveSchema = z.object({ destination_id: z.number().int().gt(0), position: z.enum(["first-child", "last-child", "left", "right", "first-sibling", "last-sibling"]).nullable().optional() });
+
+export type PageRevertSchema = z.infer<typeof PageRevertSchema>;
+export const PageRevertSchema = z.object({ revision_id: z.number().int().gt(0) });
+
+export type PageCreateAliasSchema = z.infer<typeof PageCreateAliasSchema>;
+export const PageCreateAliasSchema = z.object({ destination_id: z.number().int().gt(0).nullable(), recursive: z.boolean().default(false), slug: z.string().nullable() }).partial();
+
+export type PageCopyForTranslationSchema = z.infer<typeof PageCopyForTranslationSchema>;
+export const PageCopyForTranslationSchema = z.object({ locale: z.string(), copy_parents: z.boolean().default(false), alias: z.boolean().default(false), recursive: z.boolean().default(false) });
+
+export type ContentTypeSummarySchema = z.infer<typeof ContentTypeSummarySchema>;
+export const ContentTypeSummarySchema = z.object({ name: z.string(), label: z.string() });
+
+export type ContentTypeListSchema = z.infer<typeof ContentTypeListSchema>;
+export const ContentTypeListSchema = z.object({ types: z.array(ContentTypeSummarySchema) });
+
+export type SchemaDetailResponse = z.infer<typeof SchemaDetailResponse>;
+export const SchemaDetailResponse = z.object({ read: z.record(z.string(), z.unknown()).nullable(), create: z.record(z.string(), z.unknown()).nullable(), patch: z.record(z.string(), z.unknown()).nullable() }).partial();
+
+export type SiteSchema = z.infer<typeof SiteSchema>;
+export const SiteSchema = z.object({ id: z.number().int(), hostname: z.string(), port: z.number().int(), site_name: z.string(), root_page_id: z.number().int(), is_default_site: z.boolean() });
+
+export type PagedSiteSchema = z.infer<typeof PagedSiteSchema>;
+export const PagedSiteSchema = z.object({ items: z.array(SiteSchema), count: z.number().int() });
+
+export type SiteInputSchema = z.infer<typeof SiteInputSchema>;
+export const SiteInputSchema = z.object({ hostname: z.string(), port: z.number().int().default(80), site_name: z.string().default(""), root_page_id: z.number().int(), is_default_site: z.boolean().default(false) });
+
+export type WhoAmIProfileSchema = z.infer<typeof WhoAmIProfileSchema>;
+export const WhoAmIProfileSchema = z.object({ avatar_url: z.string().nullable() });
+
+export type WhoAmIUserSchema = z.infer<typeof WhoAmIUserSchema>;
+export const WhoAmIUserSchema = z.object({ id: z.string(), username: z.string(), email: z.string(), first_name: z.string(), last_name: z.string(), is_superuser: z.boolean() });
+
+export type WhoAmISchema = z.infer<typeof WhoAmISchema>;
+export const WhoAmISchema = z.object({ user: WhoAmIUserSchema, profile: WhoAmIProfileSchema, groups: z.array(z.string()) });
+
+export type BreadIngredientMetaSchema = z.infer<typeof BreadIngredientMetaSchema>;
+export const BreadIngredientMetaSchema = z.object({ type: z.literal("breads.BreadIngredient"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional(), detail_url: z.string().nullable().optional() });
+
+export type BreadIngredientSchema = z.infer<typeof BreadIngredientSchema>;
+export const BreadIngredientSchema = z.object({ meta: BreadIngredientMetaSchema, id: z.number().int().nullable().optional(), name: z.string().max(255) });
+
+export type BreadTypeSchema = z.infer<typeof BreadTypeSchema>;
+export const BreadTypeSchema = z.object({ meta: BreadTypeMetaSchema, id: z.number().int().nullable().optional(), title: z.string().max(255) });
+
+export type FooterTextMetaSchema = z.infer<typeof FooterTextMetaSchema>;
+export const FooterTextMetaSchema = z.object({ type: z.literal("base.FooterText"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional(), detail_url: z.string().nullable().optional() });
+
+export type FooterTextSchema = z.infer<typeof FooterTextSchema>;
+export const FooterTextSchema = z.object({ meta: FooterTextMetaSchema, id: z.number().int().nullable().optional(), body: z.string().nullable().optional() });
+
+export type PersonSchema = z.infer<typeof PersonSchema>;
+export const PersonSchema = z.object({ meta: PersonMetaSchema, id: z.number().int().nullable().optional(), first_name: z.string().max(254), last_name: z.string().max(254), job_title: z.string().max(254), image: ImageForeignKeySchema.nullable().optional(), image_avatar: z.unknown().optional(), image_listing: z.unknown().optional() });
+
+export type PagedAnnotated = z.infer<typeof PagedAnnotated>;
+export const PagedAnnotated = z.object({ items: z.array(z.union([BreadIngredientSchema, BreadTypeSchema, FooterTextSchema, PersonSchema])), count: z.number().int() });
+
+export type BreadIngredientCreateMetaSchema = z.infer<typeof BreadIngredientCreateMetaSchema>;
+export const BreadIngredientCreateMetaSchema = z.object({ type: z.literal("breads.BreadIngredient").nullable(), action: z.literal("publish").nullable().optional() });
+
+export type BreadIngredientCreateSchema = z.infer<typeof BreadIngredientCreateSchema>;
+export const BreadIngredientCreateSchema = z.object({ meta: BreadIngredientCreateMetaSchema.nullable() }).partial();
+
+export type BreadTypeCreateMetaSchema = z.infer<typeof BreadTypeCreateMetaSchema>;
+export const BreadTypeCreateMetaSchema = z.object({ type: z.literal("breads.BreadType").nullable() });
+
+export type BreadTypeCreateSchema = z.infer<typeof BreadTypeCreateSchema>;
+export const BreadTypeCreateSchema = z.object({ meta: BreadTypeCreateMetaSchema.nullable() }).partial();
+
+export type FooterTextCreateMetaSchema = z.infer<typeof FooterTextCreateMetaSchema>;
+export const FooterTextCreateMetaSchema = z.object({ type: z.literal("base.FooterText").nullable(), action: z.literal("publish").nullable().optional() });
+
+export type FooterTextCreateSchema = z.infer<typeof FooterTextCreateSchema>;
+export const FooterTextCreateSchema = z.object({ meta: FooterTextCreateMetaSchema.nullable() }).partial();
+
+export type PersonCreateMetaSchema = z.infer<typeof PersonCreateMetaSchema>;
+export const PersonCreateMetaSchema = z.object({ type: z.literal("base.Person").nullable(), action: z.literal("publish").nullable().optional() });
+
+export type PersonCreateSchema = z.infer<typeof PersonCreateSchema>;
+export const PersonCreateSchema = z.object({ meta: PersonCreateMetaSchema.nullable() }).partial();
+
+export type BreadIngredientPatchMetaSchema = z.infer<typeof BreadIngredientPatchMetaSchema>;
+export const BreadIngredientPatchMetaSchema = z.object({ type: z.literal("breads.BreadIngredient").nullable(), action: z.literal("publish").nullable().optional() });
+
+export type BreadIngredientPatchSchema = z.infer<typeof BreadIngredientPatchSchema>;
+export const BreadIngredientPatchSchema = z.object({ meta: BreadIngredientPatchMetaSchema.nullable() }).partial();
+
+export type BreadTypePatchMetaSchema = z.infer<typeof BreadTypePatchMetaSchema>;
+export const BreadTypePatchMetaSchema = z.object({ type: z.literal("breads.BreadType").nullable() });
+
+export type BreadTypePatchSchema = z.infer<typeof BreadTypePatchSchema>;
+export const BreadTypePatchSchema = z.object({ meta: BreadTypePatchMetaSchema.nullable() }).partial();
+
+export type FooterTextPatchMetaSchema = z.infer<typeof FooterTextPatchMetaSchema>;
+export const FooterTextPatchMetaSchema = z.object({ type: z.literal("base.FooterText").nullable(), action: z.literal("publish").nullable().optional() });
+
+export type FooterTextPatchSchema = z.infer<typeof FooterTextPatchSchema>;
+export const FooterTextPatchSchema = z.object({ meta: FooterTextPatchMetaSchema.nullable() }).partial();
+
+export type PersonPatchMetaSchema = z.infer<typeof PersonPatchMetaSchema>;
+export const PersonPatchMetaSchema = z.object({ type: z.literal("base.Person").nullable(), action: z.literal("publish").nullable().optional() });
+
+export type PersonPatchSchema = z.infer<typeof PersonPatchSchema>;
+export const PersonPatchSchema = z.object({ meta: PersonPatchMetaSchema.nullable() }).partial();
+
+export type SnippetRevisionDetailSchema = z.infer<typeof SnippetRevisionDetailSchema>;
+export const SnippetRevisionDetailSchema = z.object({ meta: BaseMetaSchema, id: z.number().int().gt(0), object_id: z.string(), created_at: z.iso.datetime(), user_id: z.union([z.number().int(), z.string(), z.uuid(), z.null()]).optional(), object_str: z.string(), approved_go_live_at: z.iso.datetime().nullable().optional(), content_type: ContentTypeSchema, base_content_type: ContentTypeSchema, content_object: z.union([BreadIngredientSchema, BreadTypeSchema, FooterTextSchema, PersonSchema]) });
+
+export type SnippetRevertSchema = z.infer<typeof SnippetRevertSchema>;
+export const SnippetRevertSchema = z.object({ revision_id: z.number().int().gt(0) });
+
+export type SnippetCopyForTranslationSchema = z.infer<typeof SnippetCopyForTranslationSchema>;
+export const SnippetCopyForTranslationSchema = z.object({ locale: z.string() });
+
+export type DocumentDetailMetaSchema = z.infer<typeof DocumentDetailMetaSchema>;
+export const DocumentDetailMetaSchema = z.object({ type: z.literal("wagtaildocs.Document"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional(), detail_url: z.string().nullable().optional(), tags: z.array(z.string()).default([]), download_url: z.string().nullable().optional() });
+
+export type DocumentSchema = z.infer<typeof DocumentSchema>;
+export const DocumentSchema = z.object({ meta: DocumentDetailMetaSchema, id: z.number().int().nullable().optional(), title: z.string(), collection: CollectionForeignKeySchema });
+
+export type PagedDocumentSchema = z.infer<typeof PagedDocumentSchema>;
+export const PagedDocumentSchema = z.object({ items: z.array(DocumentSchema), count: z.number().int() });
+
+export type DocumentPatchSchema = z.infer<typeof DocumentPatchSchema>;
+export const DocumentPatchSchema = z.object({ title: z.string().max(255).nullable(), collection_id: z.number().int().nullable() }).partial();
+
+export type ImageDetailMetaSchema = z.infer<typeof ImageDetailMetaSchema>;
+export const ImageDetailMetaSchema = z.object({ type: z.literal("wagtailimages.Image"), warnings: z.array(z.union([RichTextRemoval, z.string()])).nullable().optional(), detail_url: z.string().nullable().optional(), tags: z.array(z.string()).default([]), download_url: z.string().nullable().optional() });
+
+export type ImageSchema = z.infer<typeof ImageSchema>;
+export const ImageSchema = z.object({ meta: ImageDetailMetaSchema, id: z.number().int().nullable().optional(), title: z.string(), width: z.number().int(), height: z.number().int(), description: z.string().nullable().optional(), collection: CollectionForeignKeySchema.optional(), focal_point_x: z.number().int().nullable().optional(), focal_point_y: z.number().int().nullable().optional(), focal_point_width: z.number().int().nullable().optional(), focal_point_height: z.number().int().nullable().optional() });
+
+export type PagedImageSchema = z.infer<typeof PagedImageSchema>;
+export const PagedImageSchema = z.object({ items: z.array(ImageSchema), count: z.number().int() });
+
+export type ImagePatchSchema = z.infer<typeof ImagePatchSchema>;
+export const ImagePatchSchema = z.object({ title: z.string().max(255).nullable(), description: z.string().max(255).nullable().default(""), collection_id: z.number().int().nullable(), focal_point_x: z.number().int().nullable(), focal_point_y: z.number().int().nullable(), focal_point_width: z.number().int().nullable(), focal_point_height: z.number().int().nullable() }).partial();
+
+export type LocaleSchema = z.infer<typeof LocaleSchema>;
+export const LocaleSchema = z.object({ meta: BaseMetaSchema, id: z.number().int().gt(0), language_code: z.string(), display_name: z.string(), is_bidi: z.boolean(), is_default: z.boolean() });
+
+export type PagedLocaleSchema = z.infer<typeof PagedLocaleSchema>;
+export const PagedLocaleSchema = z.object({ items: z.array(LocaleSchema), count: z.number().int() });
+
+export type LocaleInputSchema = z.infer<typeof LocaleInputSchema>;
+export const LocaleInputSchema = z.object({ language_code: z.string() });
+
+export type RedirectSchema = z.infer<typeof RedirectSchema>;
+export const RedirectSchema = z.object({ id: z.number().int(), old_path: z.string(), site_id: z.number().int().nullable(), is_permanent: z.boolean(), redirect_page_id: z.number().int().nullable(), redirect_page_route_path: z.string(), redirect_link: z.string(), automatically_created: z.boolean(), created_at: z.iso.datetime().nullable() });
+
+export type PagedRedirectSchema = z.infer<typeof PagedRedirectSchema>;
+export const PagedRedirectSchema = z.object({ items: z.array(RedirectSchema), count: z.number().int() });
+
+export type RedirectInputSchema = z.infer<typeof RedirectInputSchema>;
+export const RedirectInputSchema = z.object({ old_path: z.string(), site: z.number().int().nullable().optional(), is_permanent: z.boolean().default(true), redirect_page_id: z.number().int().nullable().optional(), redirect_page_route_path: z.string().default(""), redirect_link: z.string().default("") });
+
+// </Schemas>
+
+  
+  
+  

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -3,7 +3,7 @@ import api from './api';
 
 // Cache the menu items fetch
 export const getMenuItems = cache(async () => {
-  const homePage = await api.getPage('/', 'base.HomePage');
+  const homePage = await api.getPage<'base.HomePage'>('/');
   const response = await api.getPages('wagtailcore.Page', {
     child_of: `${homePage.id}`,
     show_in_menus: 'true',

--- a/models/base.ts
+++ b/models/base.ts
@@ -1,26 +1,34 @@
 import { z } from 'zod';
-import { schemas as generated } from '@/lib/generated/schemas';
+import {
+  CollectionForeignKeySchema,
+  FormFieldSchema as GeneratedFormFieldSchema,
+  FormPageSchema as GeneratedFormPageSchema,
+  GalleryPageSchema as GeneratedGalleryPageSchema,
+  HomePageSchema as GeneratedHomePageSchema,
+  PersonSchema as GeneratedPersonSchema,
+  StandardPageSchema as GeneratedStandardPageSchema,
+} from '@/lib/generated/schemas';
 import blocks from './blocks/base';
 import { pageLinkSchema, withHtmlPath } from './wagtailcore';
 import wagtailimages from './wagtailimages';
 
 // Person schema
-const personSchema = generated.PersonSchema.extend({
+const personSchema = GeneratedPersonSchema.extend({
   image: wagtailimages.Image.nullable(),
   image_listing: wagtailimages.ImageRendition.optional(),
 });
 
 // Standard Page schema
-const standardPageSchema = generated.StandardPageSchema.extend({
-  meta: withHtmlPath(generated.StandardPageSchema.shape.meta),
+const standardPageSchema = GeneratedStandardPageSchema.extend({
+  meta: withHtmlPath(GeneratedStandardPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
   body: blocks.BaseStreamBlock,
   image_hero: wagtailimages.ImageRendition.optional(),
 });
 
 // Home Page schema
-const homePageSchema = generated.HomePageSchema.extend({
-  meta: withHtmlPath(generated.HomePageSchema.shape.meta),
+const homePageSchema = GeneratedHomePageSchema.extend({
+  meta: withHtmlPath(GeneratedHomePageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
   lead_image: wagtailimages.Image.nullable(),
   body: blocks.BaseStreamBlock,
@@ -33,17 +41,17 @@ const homePageSchema = generated.HomePageSchema.extend({
 });
 
 // Gallery Page schema
-const galleryPageSchema = generated.GalleryPageSchema.extend({
-  meta: withHtmlPath(generated.GalleryPageSchema.shape.meta),
+const galleryPageSchema = GeneratedGalleryPageSchema.extend({
+  meta: withHtmlPath(GeneratedGalleryPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
-  collection: generated.CollectionForeignKeySchema.extend({
+  collection: CollectionForeignKeySchema.extend({
     id: z.number(),
   }).nullable(),
   image_hero: wagtailimages.ImageRendition.optional(),
 });
 
 // Form Field schema
-const formFieldSchema = generated.FormFieldSchema.extend({
+const formFieldSchema = GeneratedFormFieldSchema.extend({
   choices: z
     .string()
     .nullable()
@@ -51,8 +59,8 @@ const formFieldSchema = generated.FormFieldSchema.extend({
 });
 
 // Form Page schema
-const formPageSchema = generated.FormPageSchema.extend({
-  meta: withHtmlPath(generated.FormPageSchema.shape.meta),
+const formPageSchema = GeneratedFormPageSchema.extend({
+  meta: withHtmlPath(GeneratedFormPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
   body: blocks.BaseStreamBlock,
   form_fields: z.array(formFieldSchema),

--- a/models/base.ts
+++ b/models/base.ts
@@ -1,112 +1,72 @@
 import { z } from 'zod';
+import { schemas as generated } from '@/lib/generated/schemas';
 import blocks from './blocks/base';
-import wagtailcore from './wagtailcore';
+import { pageLinkSchema, withHtmlPath } from './wagtailcore';
 import wagtailimages from './wagtailimages';
 
 // Person schema
-const personSchema = z.object({
-  id: z.number().nullable(),
-  first_name: z.string().max(254),
-  last_name: z.string().max(254),
-  job_title: z.string().max(254),
+const personSchema = generated.PersonSchema.extend({
   image: wagtailimages.Image.nullable(),
-  meta: wagtailcore._BaseMeta,
-});
-
-// Footer Text schema
-const footerTextSchema = z.object({
-  id: z.number().nullable(),
-  body: z.string(),
-  meta: wagtailcore._BaseMeta,
+  image_listing: wagtailimages.ImageRendition.optional(),
 });
 
 // Standard Page schema
-const standardPageSchema = wagtailcore.Page.extend({
-  introduction: z.string(),
+const standardPageSchema = generated.StandardPageSchema.extend({
+  meta: withHtmlPath(generated.StandardPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
   body: blocks.BaseStreamBlock,
+  image_hero: wagtailimages.ImageRendition.optional(),
 });
 
 // Home Page schema
-const homePageSchema = wagtailcore.Page.extend({
+const homePageSchema = generated.HomePageSchema.extend({
+  meta: withHtmlPath(generated.HomePageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
-  hero_text: z.string().max(255),
-  hero_cta: z.string().max(255),
-  hero_cta_link: wagtailcore.Page.nullable(),
-  body: blocks.BaseStreamBlock,
   lead_image: wagtailimages.Image.nullable(),
-  lead_title: z.string().max(255),
-  lead_text: z.string().max(1000).nullable(),
-  featured_section_1_title: z.string().max(255),
-  featured_section_1: wagtailcore.Page.nullable(),
-  featured_section_2_title: z.string().max(255),
-  featured_section_2: wagtailcore.Page.nullable(),
-  featured_section_3_title: z.string().max(255),
-  featured_section_3: wagtailcore.Page.nullable(),
+  body: blocks.BaseStreamBlock,
+  hero_cta_link: pageLinkSchema.nullable(),
+  featured_section_1: pageLinkSchema.nullable(),
+  featured_section_2: pageLinkSchema.nullable(),
+  featured_section_3: pageLinkSchema.nullable(),
+  image_hero: wagtailimages.ImageRendition.optional(),
+  lead_image_promo: wagtailimages.ImageRendition.optional(),
 });
 
 // Gallery Page schema
-const galleryPageSchema = wagtailcore.Page.extend({
-  introduction: z.string(),
+const galleryPageSchema = generated.GalleryPageSchema.extend({
+  meta: withHtmlPath(generated.GalleryPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
-  body: z.array(z.any()), // StreamField
-  collection: z
-    .object({
-      id: z.number(),
-    })
-    .nullable(),
+  collection: generated.CollectionForeignKeySchema.extend({
+    id: z.number(),
+  }).nullable(),
+  image_hero: wagtailimages.ImageRendition.optional(),
 });
 
 // Form Field schema
-const formFieldSchema = z.object({
-  id: z.number().nullable(),
-  label: z.string(),
-  field_type: z.string(),
-  required: z.boolean(),
+const formFieldSchema = generated.FormFieldSchema.extend({
   choices: z
     .string()
     .nullable()
     .transform((val) => (val || '').split(',')),
-  default_value: z.string().nullable(),
-  help_text: z.string().nullable(),
 });
 
 // Form Page schema
-const formPageSchema = wagtailcore.Page.extend({
+const formPageSchema = generated.FormPageSchema.extend({
+  meta: withHtmlPath(generated.FormPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
-  body: z.array(z.any()), // StreamField
-  thank_you_text: z.string(),
-  from_address: z.union([z.email(), z.literal('')]),
-  to_address: z.union([z.email(), z.literal('')]),
-  subject: z.string(),
+  body: blocks.BaseStreamBlock,
   form_fields: z.array(formFieldSchema),
-});
-
-// Generic Settings schema
-const genericSettingsSchema = z.object({
-  id: z.number().nullable(),
-  mastodon_url: z.url().optional(),
-  github_url: z.url().optional(),
-  organisation_url: z.url().optional(),
-});
-
-// Site Settings schema
-const siteSettingsSchema = z.object({
-  id: z.number().nullable(),
-  title_suffix: z.string().max(255).default('The Wagtail Bakery'),
+  image_hero: wagtailimages.ImageRendition.optional(),
 });
 
 // Export schemas
 const schemas = {
   Person: personSchema,
-  FooterText: footerTextSchema,
   StandardPage: standardPageSchema,
   HomePage: homePageSchema,
   GalleryPage: galleryPageSchema,
   FormField: formFieldSchema,
   FormPage: formPageSchema,
-  GenericSettings: genericSettingsSchema,
-  SiteSettings: siteSettingsSchema,
 } as const;
 
 export default schemas;
@@ -114,12 +74,9 @@ export default schemas;
 // Derived TypeScript types
 export namespace base {
   export type Person = z.infer<typeof schemas.Person>;
-  export type FooterText = z.infer<typeof schemas.FooterText>;
   export type StandardPage = z.infer<typeof schemas.StandardPage>;
   export type HomePage = z.infer<typeof schemas.HomePage>;
   export type GalleryPage = z.infer<typeof schemas.GalleryPage>;
   export type FormField = z.infer<typeof schemas.FormField>;
   export type FormPage = z.infer<typeof schemas.FormPage>;
-  export type GenericSettings = z.infer<typeof schemas.GenericSettings>;
-  export type SiteSettings = z.infer<typeof schemas.SiteSettings>;
 }

--- a/models/blocks/base.test.ts
+++ b/models/blocks/base.test.ts
@@ -74,6 +74,13 @@ describe('BaseStreamBlock schema', () => {
             meta: {
               type: 'wagtailimages.Image',
               download_url: '/img.jpg',
+              rendition: {
+                url: '/img.jpg',
+                full_url: 'http://localhost:8000/img.jpg',
+                width: 800,
+                height: 600,
+                alt: 'Photo',
+              },
             },
           },
           caption: 'A photo',

--- a/models/blocks/base.ts
+++ b/models/blocks/base.ts
@@ -6,7 +6,7 @@ const captionedImageBlockSchema = z.object({
   type: z.literal('image_block'),
   id: z.string(),
   value: z.object({
-    image: wagtailimages.Image,
+    image: wagtailimages.StreamFieldImage,
     caption: z.string().optional(),
     attribution: z.string().optional(),
   }),

--- a/models/blocks/recipes.ts
+++ b/models/blocks/recipes.ts
@@ -26,7 +26,7 @@ const tableBlockSchema = z.object({
 const typedTableCellSchema = z.union([
   z.string(),
   z.number(),
-  wagtailimages.Image,
+  wagtailimages.StreamFieldImage,
 ]);
 
 // TypedTable schema

--- a/models/blog.ts
+++ b/models/blog.ts
@@ -1,29 +1,30 @@
 import { z } from 'zod';
+import { schemas as generated } from '@/lib/generated/schemas';
 import base from './base';
 import blocks from './blocks/base';
-import wagtailcore from './wagtailcore';
+import { withHtmlPath } from './wagtailcore';
 import wagtailimages from './wagtailimages';
 
 // BlogPersonRelationship schema
-const blogPersonRelationshipSchema = z.object({
-  page: wagtailcore.Page,
-  person: base.Person,
-});
+const blogPersonRelationshipSchema =
+  generated.BlogPersonRelationshipSchema.extend({
+    person: base.Person,
+  });
 
 // BlogPage schema
-const blogPageSchema = wagtailcore.Page.extend({
-  introduction: z.string(),
+const blogPageSchema = generated.BlogPageSchema.extend({
+  meta: withHtmlPath(generated.BlogPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
   body: blocks.BaseStreamBlock,
-  subtitle: z.string(),
-  tags: z.array(z.string()),
-  date_published: z.string().nullable(), // Date as ISO string
   blog_person_relationship: z.array(blogPersonRelationshipSchema),
+  image_hero: wagtailimages.ImageRendition.optional(),
+  image_listing: wagtailimages.ImageRendition.optional(),
+  image_picture_card: wagtailimages.ImageRendition.optional(),
 });
 
 // BlogIndexPage schema
-const blogIndexPageSchema = wagtailcore.Page.extend({
-  introduction: z.string(),
+const blogIndexPageSchema = generated.BlogIndexPageSchema.extend({
+  meta: withHtmlPath(generated.BlogIndexPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
 });
 

--- a/models/blog.ts
+++ b/models/blog.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
-import { schemas as generated } from '@/lib/generated/schemas';
+import {
+  BlogIndexPageSchema as GeneratedBlogIndexPageSchema,
+  BlogPageSchema as GeneratedBlogPageSchema,
+  BlogPersonRelationshipSchema as GeneratedBlogPersonRelationshipSchema,
+} from '@/lib/generated/schemas';
 import base from './base';
 import blocks from './blocks/base';
 import { withHtmlPath } from './wagtailcore';
@@ -7,13 +11,13 @@ import wagtailimages from './wagtailimages';
 
 // BlogPersonRelationship schema
 const blogPersonRelationshipSchema =
-  generated.BlogPersonRelationshipSchema.extend({
+  GeneratedBlogPersonRelationshipSchema.extend({
     person: base.Person,
   });
 
 // BlogPage schema
-const blogPageSchema = generated.BlogPageSchema.extend({
-  meta: withHtmlPath(generated.BlogPageSchema.shape.meta),
+const blogPageSchema = GeneratedBlogPageSchema.extend({
+  meta: withHtmlPath(GeneratedBlogPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
   body: blocks.BaseStreamBlock,
   blog_person_relationship: z.array(blogPersonRelationshipSchema),
@@ -23,8 +27,8 @@ const blogPageSchema = generated.BlogPageSchema.extend({
 });
 
 // BlogIndexPage schema
-const blogIndexPageSchema = generated.BlogIndexPageSchema.extend({
-  meta: withHtmlPath(generated.BlogIndexPageSchema.shape.meta),
+const blogIndexPageSchema = GeneratedBlogIndexPageSchema.extend({
+  meta: withHtmlPath(GeneratedBlogIndexPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
 });
 

--- a/models/breads.ts
+++ b/models/breads.ts
@@ -1,50 +1,33 @@
 import { z } from 'zod';
+import { schemas as generated } from '@/lib/generated/schemas';
 import blocks from './blocks/base';
-import wagtailcore from './wagtailcore';
+import { withHtmlPath } from './wagtailcore';
 import wagtailimages from './wagtailimages';
 
-// Country schema
-const countrySchema = z.object({
-  id: z.number().nullable(),
-  title: z.string().max(100),
-  meta: wagtailcore._BaseMeta,
-});
-
-// BreadIngredient schema
-const breadIngredientSchema = z.object({
-  id: z.number().nullable(),
-  name: z.string().max(255),
-  meta: wagtailcore._BaseMeta,
-});
-
-// BreadType schema
-const breadTypeSchema = z.object({
-  id: z.number().nullable(),
-  title: z.string().max(255),
-  meta: wagtailcore._BaseMeta,
-});
-
 // BreadPage schema
-const breadPageSchema = wagtailcore.Page.extend({
-  introduction: z.string(),
+const breadPageSchema = generated.BreadPageSchema.extend({
+  meta: withHtmlPath(generated.BreadPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
   body: blocks.BaseStreamBlock,
-  origin: countrySchema.nullable(),
-  bread_type: breadTypeSchema.nullable(),
-  ingredients: z.array(breadIngredientSchema),
+  bread_type: generated.BreadTypeSchema.nullable(),
+  // Bare snippet IDs in the API response; hydrated to full BreadIngredient
+  // objects (or left as a bare id if the snippet can't be resolved, e.g.
+  // draft/deleted) by lib/api.ts before rendering.
+  ingredients: z.array(
+    z.union([generated.BreadIngredientSchema, z.object({ id: z.number() })]),
+  ),
+  image_hero: wagtailimages.ImageRendition.optional(),
+  image_listing: wagtailimages.ImageRendition.optional(),
 });
 
 // BreadsIndexPage schema
-const breadsIndexPageSchema = wagtailcore.Page.extend({
-  introduction: z.string(),
+const breadsIndexPageSchema = generated.BreadsIndexPageSchema.extend({
+  meta: withHtmlPath(generated.BreadsIndexPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
 });
 
 // Export schemas
 const schemas = {
-  Country: countrySchema,
-  BreadIngredient: breadIngredientSchema,
-  BreadType: breadTypeSchema,
   BreadPage: breadPageSchema,
   BreadsIndexPage: breadsIndexPageSchema,
 } as const;
@@ -53,9 +36,6 @@ export default schemas;
 
 // Derived TypeScript types
 export namespace breads {
-  export type Country = z.infer<typeof schemas.Country>;
-  export type BreadIngredient = z.infer<typeof schemas.BreadIngredient>;
-  export type BreadType = z.infer<typeof schemas.BreadType>;
   export type BreadPage = z.infer<typeof schemas.BreadPage>;
   export type BreadsIndexPage = z.infer<typeof schemas.BreadsIndexPage>;
 }

--- a/models/breads.ts
+++ b/models/breads.ts
@@ -1,28 +1,33 @@
 import { z } from 'zod';
-import { schemas as generated } from '@/lib/generated/schemas';
+import {
+  BreadIngredientSchema,
+  BreadTypeSchema,
+  BreadPageSchema as GeneratedBreadPageSchema,
+  BreadsIndexPageSchema as GeneratedBreadsIndexPageSchema,
+} from '@/lib/generated/schemas';
 import blocks from './blocks/base';
 import { withHtmlPath } from './wagtailcore';
 import wagtailimages from './wagtailimages';
 
 // BreadPage schema
-const breadPageSchema = generated.BreadPageSchema.extend({
-  meta: withHtmlPath(generated.BreadPageSchema.shape.meta),
+const breadPageSchema = GeneratedBreadPageSchema.extend({
+  meta: withHtmlPath(GeneratedBreadPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
   body: blocks.BaseStreamBlock,
-  bread_type: generated.BreadTypeSchema.nullable(),
+  bread_type: BreadTypeSchema.nullable(),
   // Bare snippet IDs in the API response; hydrated to full BreadIngredient
   // objects (or left as a bare id if the snippet can't be resolved, e.g.
   // draft/deleted) by lib/api.ts before rendering.
   ingredients: z.array(
-    z.union([generated.BreadIngredientSchema, z.object({ id: z.number() })]),
+    z.union([BreadIngredientSchema, z.object({ id: z.number() })]),
   ),
   image_hero: wagtailimages.ImageRendition.optional(),
   image_listing: wagtailimages.ImageRendition.optional(),
 });
 
 // BreadsIndexPage schema
-const breadsIndexPageSchema = generated.BreadsIndexPageSchema.extend({
-  meta: withHtmlPath(generated.BreadsIndexPageSchema.shape.meta),
+const breadsIndexPageSchema = GeneratedBreadsIndexPageSchema.extend({
+  meta: withHtmlPath(GeneratedBreadsIndexPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
 });
 

--- a/models/locations.ts
+++ b/models/locations.ts
@@ -1,36 +1,29 @@
 import { z } from 'zod';
+import { schemas as generated } from '@/lib/generated/schemas';
 import blocks from './blocks/base';
-import wagtailcore from './wagtailcore';
+import { withHtmlPath } from './wagtailcore';
 import wagtailimages from './wagtailimages';
 
 // Operating Hours schema
-const operatingHoursSchema = z.object({
-  id: z.number().nullable(),
+const operatingHoursSchema = generated.LocationOperatingHoursSchema.extend({
   day: z.enum(['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']),
-  opening_time: z.string().nullable(), // Time as string HH:MM
-  closing_time: z.string().nullable(), // Time as string HH:MM
-  closed: z.boolean(),
 });
 
 // LocationPage schema
-const locationPageSchema = wagtailcore.Page.extend({
-  introduction: z.string(),
+const locationPageSchema = generated.LocationPageSchema.extend({
+  meta: withHtmlPath(generated.LocationPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
   body: blocks.BaseStreamBlock,
   is_open: z.boolean(),
-  address: z.string(),
-  lat_long: z
-    .string()
-    .regex(
-      /^((-?\d+(\.\d+)?),\s*(-?\d+(\.\d+)?))?$/,
-      'Lat Long must be a comma-separated numeric lat and long',
-    ),
   hours_of_operation: z.array(operatingHoursSchema),
+  image_hero: wagtailimages.ImageRendition.optional(),
+  image_location_card: wagtailimages.ImageRendition.optional(),
+  image_picture_card: wagtailimages.ImageRendition.optional(),
 });
 
 // LocationsIndexPage schema
-const locationsIndexPageSchema = wagtailcore.Page.extend({
-  introduction: z.string(),
+const locationsIndexPageSchema = generated.LocationsIndexPageSchema.extend({
+  meta: withHtmlPath(generated.LocationsIndexPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
 });
 

--- a/models/locations.ts
+++ b/models/locations.ts
@@ -1,17 +1,21 @@
 import { z } from 'zod';
-import { schemas as generated } from '@/lib/generated/schemas';
+import {
+  LocationOperatingHoursSchema as GeneratedLocationOperatingHoursSchema,
+  LocationPageSchema as GeneratedLocationPageSchema,
+  LocationsIndexPageSchema as GeneratedLocationsIndexPageSchema,
+} from '@/lib/generated/schemas';
 import blocks from './blocks/base';
 import { withHtmlPath } from './wagtailcore';
 import wagtailimages from './wagtailimages';
 
 // Operating Hours schema
-const operatingHoursSchema = generated.LocationOperatingHoursSchema.extend({
+const operatingHoursSchema = GeneratedLocationOperatingHoursSchema.extend({
   day: z.enum(['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']),
 });
 
 // LocationPage schema
-const locationPageSchema = generated.LocationPageSchema.extend({
-  meta: withHtmlPath(generated.LocationPageSchema.shape.meta),
+const locationPageSchema = GeneratedLocationPageSchema.extend({
+  meta: withHtmlPath(GeneratedLocationPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
   body: blocks.BaseStreamBlock,
   is_open: z.boolean(),
@@ -22,8 +26,8 @@ const locationPageSchema = generated.LocationPageSchema.extend({
 });
 
 // LocationsIndexPage schema
-const locationsIndexPageSchema = generated.LocationsIndexPageSchema.extend({
-  meta: withHtmlPath(generated.LocationsIndexPageSchema.shape.meta),
+const locationsIndexPageSchema = GeneratedLocationsIndexPageSchema.extend({
+  meta: withHtmlPath(GeneratedLocationsIndexPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
 });
 

--- a/models/people.ts
+++ b/models/people.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
+import { schemas as generated } from '@/lib/generated/schemas';
 import blocks from './blocks/base';
-import breads from './breads';
-import wagtailcore from './wagtailcore';
+import { withHtmlPath } from './wagtailcore';
 import wagtailimages from './wagtailimages';
 
 const socialMediaLinkSchema = z.object({
@@ -21,16 +21,17 @@ const socialMediaLinkSchema = z.object({
   }),
 });
 
-const personPageSchema = wagtailcore.Page.extend({
-  introduction: z.string(),
+const personPageSchema = generated.PersonPageSchema.extend({
+  meta: withHtmlPath(generated.PersonPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
   body: blocks.BaseStreamBlock,
-  location: breads.Country.nullable(),
   social_links: z.array(socialMediaLinkSchema),
+  image_hero: wagtailimages.ImageRendition.optional(),
+  image_listing: wagtailimages.ImageRendition.optional(),
 });
 
-const peopleIndexPageSchema = wagtailcore.Page.extend({
-  introduction: z.string(),
+const peopleIndexPageSchema = generated.PeopleIndexPageSchema.extend({
+  meta: withHtmlPath(generated.PeopleIndexPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
 });
 

--- a/models/people.ts
+++ b/models/people.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
-import { schemas as generated } from '@/lib/generated/schemas';
+import {
+  PeopleIndexPageSchema as GeneratedPeopleIndexPageSchema,
+  PersonPageSchema as GeneratedPersonPageSchema,
+} from '@/lib/generated/schemas';
 import blocks from './blocks/base';
 import { withHtmlPath } from './wagtailcore';
 import wagtailimages from './wagtailimages';
@@ -21,8 +24,8 @@ const socialMediaLinkSchema = z.object({
   }),
 });
 
-const personPageSchema = generated.PersonPageSchema.extend({
-  meta: withHtmlPath(generated.PersonPageSchema.shape.meta),
+const personPageSchema = GeneratedPersonPageSchema.extend({
+  meta: withHtmlPath(GeneratedPersonPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
   body: blocks.BaseStreamBlock,
   social_links: z.array(socialMediaLinkSchema),
@@ -30,8 +33,8 @@ const personPageSchema = generated.PersonPageSchema.extend({
   image_listing: wagtailimages.ImageRendition.optional(),
 });
 
-const peopleIndexPageSchema = generated.PeopleIndexPageSchema.extend({
-  meta: withHtmlPath(generated.PeopleIndexPageSchema.shape.meta),
+const peopleIndexPageSchema = GeneratedPeopleIndexPageSchema.extend({
+  meta: withHtmlPath(GeneratedPeopleIndexPageSchema.shape.meta),
   image: wagtailimages.Image.nullable(),
 });
 

--- a/models/recipes.ts
+++ b/models/recipes.ts
@@ -1,28 +1,26 @@
 import { z } from 'zod';
+import { schemas as generated } from '@/lib/generated/schemas';
 import base from './base';
 import blocks from './blocks';
-import wagtailcore from './wagtailcore';
+import { withHtmlPath } from './wagtailcore';
 
 // RecipePersonRelationship schema
-const recipePersonRelationshipSchema = z.object({
-  id: z.number().nullable(),
-  person: base.Person,
-});
+const recipePersonRelationshipSchema =
+  generated.RecipePersonRelationshipSchema.extend({
+    person: base.Person,
+  });
 
 // RecipePage schema
-const recipePageSchema = wagtailcore.Page.extend({
-  date_published: z.string().nullable(), // Date as ISO string
-  subtitle: z.string().max(255),
-  introduction: z.string().max(500),
+const recipePageSchema = generated.RecipePageSchema.extend({
+  meta: withHtmlPath(generated.RecipePageSchema.shape.meta),
   backstory: blocks.base.BaseStreamBlock,
-  recipe_headline: z.string().max(120),
   body: blocks.recipes.RecipeStreamBlock,
   recipe_person_relationship: z.array(recipePersonRelationshipSchema),
 });
 
 // RecipeIndexPage schema
-const recipeIndexPageSchema = wagtailcore.Page.extend({
-  introduction: z.string(),
+const recipeIndexPageSchema = generated.RecipeIndexPageSchema.extend({
+  meta: withHtmlPath(generated.RecipeIndexPageSchema.shape.meta),
 });
 
 // Export schemas

--- a/models/recipes.ts
+++ b/models/recipes.ts
@@ -1,26 +1,30 @@
 import { z } from 'zod';
-import { schemas as generated } from '@/lib/generated/schemas';
+import {
+  RecipeIndexPageSchema as GeneratedRecipeIndexPageSchema,
+  RecipePageSchema as GeneratedRecipePageSchema,
+  RecipePersonRelationshipSchema as GeneratedRecipePersonRelationshipSchema,
+} from '@/lib/generated/schemas';
 import base from './base';
 import blocks from './blocks';
 import { withHtmlPath } from './wagtailcore';
 
 // RecipePersonRelationship schema
 const recipePersonRelationshipSchema =
-  generated.RecipePersonRelationshipSchema.extend({
+  GeneratedRecipePersonRelationshipSchema.extend({
     person: base.Person,
   });
 
 // RecipePage schema
-const recipePageSchema = generated.RecipePageSchema.extend({
-  meta: withHtmlPath(generated.RecipePageSchema.shape.meta),
+const recipePageSchema = GeneratedRecipePageSchema.extend({
+  meta: withHtmlPath(GeneratedRecipePageSchema.shape.meta),
   backstory: blocks.base.BaseStreamBlock,
   body: blocks.recipes.RecipeStreamBlock,
   recipe_person_relationship: z.array(recipePersonRelationshipSchema),
 });
 
 // RecipeIndexPage schema
-const recipeIndexPageSchema = generated.RecipeIndexPageSchema.extend({
-  meta: withHtmlPath(generated.RecipeIndexPageSchema.shape.meta),
+const recipeIndexPageSchema = GeneratedRecipeIndexPageSchema.extend({
+  meta: withHtmlPath(GeneratedRecipeIndexPageSchema.shape.meta),
 });
 
 // Export schemas

--- a/models/wagtailcore.ts
+++ b/models/wagtailcore.ts
@@ -1,68 +1,97 @@
 import { z } from 'zod';
+import { schemas as generated } from '@/lib/generated/schemas';
 
 // Utility function to remove origin from URL
 const removeOrigin = (url: string): string => {
   return url.replace(/^(?:https?:\/\/[^/]+)?/, '');
 };
 
-// Base meta fields schema for all models
-const baseMetaSchema = z.object({
-  type: z.string(),
-  detail_url: z.string().optional(),
+// Base meta fields schema for all models (snippets etc.)
+const baseMetaSchema = generated.BasePageMetaSchema.pick({
+  type: true,
+  detail_url: true,
 });
 
-const basePageMetaSchema = baseMetaSchema.extend({
-  html_url: z.string(),
+// A lightweight reference to another page (subset of fields), with
+// html_path derived from html_url. Used both for `meta.parent`/`alias_of`,
+// and for page FK fields elsewhere (e.g. HomePage.hero_cta_link) once
+// lib/api.ts has hydrated their `{id, meta}` stub to a full page fetch -
+// only this reduced shape is picked out of that larger response.
+export const pageLinkSchema = generated.SimpleBasePageSchema.extend({
+  meta: generated.SimpleBasePageMetaSchema.transform(
+    (data): typeof data & { html_path: string } => {
+      const typed = data as { html_url?: string | null };
+      return {
+        ...data,
+        html_path: removeOrigin(typed.html_url ?? ''),
+      };
+    },
+  ),
 });
 
-// Parent meta schema (subset of fields)
-const parentMetaSchema = basePageMetaSchema.transform((data) => ({
-  ...data,
-  // Remove origin from html_url to get the path
-  html_path: removeOrigin(data.html_url),
-}));
+const pageLinksShape = {
+  parent: pageLinkSchema.nullable().optional(),
+  alias_of: pageLinkSchema.nullable().optional(),
+};
 
-// Base page schema (without meta to avoid circular reference)
-const basePageSchema = z.object({
+/**
+ * Adds a derived `html_path` field (origin-stripped `html_url`) to a page
+ * meta schema, and gives its `parent`/`alias_of` fields (present on every
+ * generated page meta schema, always typed as a plain `SimpleBasePageSchema`
+ * with no `html_path`) the same `pageLinkSchema` treatment. Used by every
+ * page content type, as `meta.html_path` is read throughout the app for
+ * internal links, including via `meta.parent`/`meta.alias_of`.
+ *
+ * The cast inside the transform sidesteps a zod v4 type-inference issue
+ * where `.extend()`'s computed return type, when built from a generic
+ * `Shape` parameter, doesn't resolve field types (e.g. `html_url`)
+ * concretely enough for the following `.transform()` to see them. The
+ * runtime behaviour (spread + derive html_path) is straightforward; only
+ * the static type needed help.
+ */
+type ShapeOutput<Shape extends z.ZodRawShape> = {
+  [K in keyof Shape as undefined extends z.output<Shape[K]>
+    ? never
+    : K]: z.output<Shape[K]>;
+} & {
+  [K in keyof Shape as undefined extends z.output<Shape[K]>
+    ? K
+    : never]?: z.output<Shape[K]>;
+};
+
+export function withHtmlPath<
+  Shape extends z.ZodRawShape & {
+    html_url: z.ZodType<string | null | undefined>;
+  },
+>(metaSchema: z.ZodObject<Shape>) {
+  return metaSchema.extend(pageLinksShape).transform(
+    (
+      data,
+    ): ShapeOutput<Shape> & {
+      parent?: z.output<typeof pageLinkSchema> | null;
+      alias_of?: z.output<typeof pageLinkSchema> | null;
+      html_path: string;
+    } => {
+      const typed = data as unknown as ShapeOutput<Shape>;
+      const htmlUrl = (data as { html_url?: string | null }).html_url;
+      return {
+        ...typed,
+        html_path: removeOrigin(htmlUrl ?? ''),
+      };
+    },
+  );
+}
+
+// Full page schema, with html_path derived from html_url
+const pageSchema = generated.PageSchema.extend({
+  meta: withHtmlPath(generated.PageSchema.shape.meta),
   id: z.number(),
-  title: z.string(),
-});
-
-// Parent page schema (with limited meta)
-const parentPageSchema = basePageSchema.extend({
-  meta: parentMetaSchema,
-});
-
-// Full meta schema (all fields)
-const pageMetaSchema = basePageMetaSchema
-  .extend({
-    slug: z.string(),
-    show_in_menus: z.boolean(),
-    seo_title: z.string(),
-    search_description: z.string(),
-    first_published_at: z.string().nullable(),
-    alias_of: parentPageSchema.nullable(),
-    locale: z.string(),
-    parent: z
-      .lazy(() => parentPageSchema)
-      .nullable()
-      .optional(),
-  })
-  .transform((data) => ({
-    ...data,
-    html_path: removeOrigin(data.html_url),
-  }));
-
-// Full page schema
-const pageSchema = basePageSchema.extend({
-  meta: pageMetaSchema,
 });
 
 // Export schemas
 const schemas = {
   Page: pageSchema,
-  _PageMeta: pageMetaSchema, // not a real model
-  _BaseMeta: baseMetaSchema, // not a real model
+  _BaseMeta: baseMetaSchema,
 } as const;
 
 export default schemas;
@@ -70,5 +99,5 @@ export default schemas;
 // Derived TypeScript types
 export namespace wagtailcore {
   export type Page = z.infer<typeof schemas.Page>;
-  export type _PageMeta = z.infer<typeof schemas._PageMeta>;
+  export type _BaseMeta = z.infer<typeof schemas._BaseMeta>;
 }

--- a/models/wagtailcore.ts
+++ b/models/wagtailcore.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
-import { schemas as generated } from '@/lib/generated/schemas';
+import {
+  BasePageMetaSchema,
+  PageSchema as GeneratedPageSchema,
+  SimpleBasePageMetaSchema,
+  SimpleBasePageSchema,
+} from '@/lib/generated/schemas';
 
 // Utility function to remove origin from URL
 const removeOrigin = (url: string): string => {
@@ -7,7 +12,7 @@ const removeOrigin = (url: string): string => {
 };
 
 // Base meta fields schema for all models (snippets etc.)
-const baseMetaSchema = generated.BasePageMetaSchema.pick({
+const baseMetaSchema = BasePageMetaSchema.pick({
   type: true,
   detail_url: true,
 });
@@ -17,8 +22,8 @@ const baseMetaSchema = generated.BasePageMetaSchema.pick({
 // and for page FK fields elsewhere (e.g. HomePage.hero_cta_link) once
 // lib/api.ts has hydrated their `{id, meta}` stub to a full page fetch -
 // only this reduced shape is picked out of that larger response.
-export const pageLinkSchema = generated.SimpleBasePageSchema.extend({
-  meta: generated.SimpleBasePageMetaSchema.transform(
+export const pageLinkSchema = SimpleBasePageSchema.extend({
+  meta: SimpleBasePageMetaSchema.transform(
     (data): typeof data & { html_path: string } => {
       const typed = data as { html_url?: string | null };
       return {
@@ -82,9 +87,15 @@ export function withHtmlPath<
   );
 }
 
-// Full page schema, with html_path derived from html_url
-const pageSchema = generated.PageSchema.extend({
-  meta: withHtmlPath(generated.PageSchema.shape.meta),
+// Full page schema, with html_path derived from html_url. `meta.type` is
+// widened from the generated `z.literal("wagtailcore.Page")` to `z.string()`
+// - every specific page type (base.StandardPage, blog.BlogPage, etc.) must
+// structurally satisfy this base Page type for PageComponentProps<T> to
+// work, which the literal blocks.
+const pageSchema = GeneratedPageSchema.extend({
+  meta: withHtmlPath(
+    GeneratedPageSchema.shape.meta.extend({ type: z.string() }),
+  ),
   id: z.number(),
 });
 

--- a/models/wagtailimages.ts
+++ b/models/wagtailimages.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
-import { schemas as generated } from '@/lib/generated/schemas';
+import { ImageSchema as GeneratedImageSchema } from '@/lib/generated/schemas';
 
 // Full image schema (as returned by GET /images/{id}/, and as hydrated by
 // lib/api.ts in place of the thin `ImageForeignKeySchema` stubs nested
 // inside page/snippet responses).
-const imageSchema = generated.ImageSchema.extend({
-  meta: generated.ImageSchema.shape.meta.extend({
+const imageSchema = GeneratedImageSchema.extend({
+  meta: GeneratedImageSchema.shape.meta.extend({
     download_url: z
       .string()
       .transform((url) => `${process.env.NEXT_PUBLIC_WAGTAIL_API_HOST!}${url}`),

--- a/models/wagtailimages.ts
+++ b/models/wagtailimages.ts
@@ -1,20 +1,49 @@
 import { z } from 'zod';
+import { schemas as generated } from '@/lib/generated/schemas';
 
-const imageSchema = z.object({
-  id: z.number(),
-  title: z.string(),
-  meta: z.object({
-    type: z.string(),
-    detail_url: z.string().optional(),
+// Full image schema (as returned by GET /images/{id}/, and as hydrated by
+// lib/api.ts in place of the thin `ImageForeignKeySchema` stubs nested
+// inside page/snippet responses).
+const imageSchema = generated.ImageSchema.extend({
+  meta: generated.ImageSchema.shape.meta.extend({
     download_url: z
       .string()
       .transform((url) => `${process.env.NEXT_PUBLIC_WAGTAIL_API_HOST!}${url}`),
   }),
 });
 
+// Pre-rendered image rendition schema (e.g. `image_hero`, `image_listing`,
+// `image_picture_card` on page schemas) - ready to use directly, no
+// hydration required.
+const imageRenditionSchema = z.object({
+  url: z.string(),
+  full_url: z.string(),
+  width: z.number(),
+  height: z.number(),
+  alt: z.string(),
+});
+
+// Images nested inside StreamField block values are expanded inline by v3,
+// but as a leaner shape than the full `GET /images/{id}/` response (no
+// top-level width/height) - dimensions/alt instead come from a `rendition`
+// sub-object alongside `download_url`.
+const streamFieldImageSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  meta: z.object({
+    type: z.string(),
+    download_url: z
+      .string()
+      .transform((url) => `${process.env.NEXT_PUBLIC_WAGTAIL_API_HOST!}${url}`),
+    rendition: imageRenditionSchema,
+  }),
+});
+
 // Export schemas
 const schemas = {
   Image: imageSchema,
+  ImageRendition: imageRenditionSchema,
+  StreamFieldImage: streamFieldImageSchema,
 } as const;
 
 export default schemas;
@@ -22,4 +51,6 @@ export default schemas;
 // Derived TypeScript types
 export namespace wagtailimages {
   export type Image = z.infer<typeof schemas.Image>;
+  export type ImageRendition = z.infer<typeof schemas.ImageRendition>;
+  export type StreamFieldImage = z.infer<typeof schemas.StreamFieldImage>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "^6.0.0",
         "jsdom": "^30.0.0",
-        "openapi-zod-client": "^1.18.3",
+        "typed-openapi": "^4.0.0",
         "typescript": "^6.0.3",
         "vitest": "^4.0.18"
       }
@@ -35,13 +35,12 @@
       "license": "MIT"
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "11.7.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.7.2.tgz",
-      "integrity": "sha512-4gY54eEGEstClvEkGnwVkTkrx0sqwemEFG5OSRRn3tD91XH0+Q8XIkYIfo7IwEWPpJZwILb9GUXeShtplRc/eA==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.0.1.tgz",
+      "integrity": "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
         "@types/json-schema": "^7.0.15",
         "js-yaml": "^4.1.0"
       },
@@ -70,16 +69,15 @@
       "license": "MIT"
     },
     "node_modules/@apidevtools/swagger-parser": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.1.1.tgz",
-      "integrity": "sha512-u/kozRnsPO/x8QtKYJOqoGtC4kH6yg1lfYkB9Au0WhYB0FNLpyFusttQtvhlwjtG3rOwiRz4D8DnnXa8iEpIKA==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-12.1.0.tgz",
+      "integrity": "sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "11.7.2",
+        "@apidevtools/json-schema-ref-parser": "14.0.1",
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
-        "@jsdevtools/ono": "^7.1.3",
         "ajv": "^8.17.1",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.2"
@@ -742,6 +740,448 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@exodus/bytes": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
@@ -1276,24 +1716,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@jsdevtools/ono": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@liuli-util/fs-extra": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@liuli-util/fs-extra/-/fs-extra-0.1.0.tgz",
-      "integrity": "sha512-eaAyDyMGT23QuRGbITVY3SOJff3G9ekAAyGqB9joAnTBmqvFN+9a1FazOdO70G6IUqgpKV451eBHYSRcOJ/FNQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/fs-extra": "^9.0.13",
-        "fs-extra": "^10.1.0"
-      }
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
@@ -1455,6 +1877,353 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm-eabi": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.59.0.tgz",
+      "integrity": "sha512-bNTnfbuG7sAwb2PakMNaDukx5kXeW9duXOBeWtTOiLz3fXz3q2DlWguufPZ+c2IHEVrRXHD+M4aUgEWm841LDA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm64": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.59.0.tgz",
+      "integrity": "sha512-R/Sn7z52QtdAKNqQLLY0EK7hVMjXiz3XUlvoCFCm/60jgIzAnQtiqLKBCFaBkimCQL5rs2ezPMcicpjCsrl54Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-arm64": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.59.0.tgz",
+      "integrity": "sha512-vm/ynUqE4HjC0ZIEjmXv1UJu1/GngccQ+T+TJudTMxUxm6r+GQTg1TO3E5jJfI71pBaXxSzs1+vWHIwuilGHhw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-x64": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.59.0.tgz",
+      "integrity": "sha512-uTtYDpLN/obfKVWGpgEc8BqYlLZBQTPz2uYEvLRy3HPZxjZ34wiFzukUBU2bf64JuCYZI//GTV1EOMmWlPjf/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-freebsd-x64": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.59.0.tgz",
+      "integrity": "sha512-e2UnxL/ifStSPy8ffBCDbdy595SYsGy+U1pur4G65TuMmWxAMBzYGG7atZo/3mp515p8rZdsflxVD/E1FAdPLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.59.0.tgz",
+      "integrity": "sha512-LtdeZ1l0urxte3VNi3g8cocZwv1xGM1NKHSgF/fJEEVhyQmlgGh7WFWKFd/pNuO7djfvPNtNO1+MS+FEWkgVSA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.59.0.tgz",
+      "integrity": "sha512-dBTciSsj9GTMl7p+h2gMSI0hoPn2ijfc/dUsbnWsP0RbwgPl2r0C/5zkMb3Pb+gGj17LH7f1o4qLo9aes/pAvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-gnu": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.59.0.tgz",
+      "integrity": "sha512-tXVdJ/JINsNWdponPHN0OuKHtC+HdpyoS9sd6IDPNiiEYsRki8b7tefRZ1iMnRkdbyT4SEbguWsr6o+5awvbPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-musl": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.59.0.tgz",
+      "integrity": "sha512-RRTq38i2zT5fnw6XGHjvT6w2mh6x/G3m6AZcAZ56OTDTT/lsOeYnG3SVjwmH40z5kPqF+lf+o35e6m6PpKy9Dw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.59.0.tgz",
+      "integrity": "sha512-lD3k7glAJSaXW0D6xzu8VOZbYbosvy+0ktOVkfLEoQF5HJlMSxTQ2KNW0JO+08ccP/1ElOKktVEMI0fqRbVB4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.59.0.tgz",
+      "integrity": "sha512-WH5ZP1RbuHKBO/yfPRQKpNO/ijHcEDNbnmC4VPf/Bcd3+mbMAZpRiJWRa1PL5bREdIZZHo343mk3sqlc9x7Usw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-musl": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.59.0.tgz",
+      "integrity": "sha512-743wOiaI9RZY4QVGkWkfGRavD5ZJUJ6gscFjVrVu1dP8AZh9jM+a6v3NhlR+OIzHdS6DhLM96w+gcVskskz7rw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-s390x-gnu": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.59.0.tgz",
+      "integrity": "sha512-xjRXQsRnrRZCcCkIEnbd2lmsQNobtwwkJxdy2bWXhZ1lIN0ouZwsBXRsoovW3yATuziAYwr9HMiQuR/Cc75NIw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-gnu": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.59.0.tgz",
+      "integrity": "sha512-4hNjqq/Rbr9B+StY9zMMAfm72+mtM4v80xYL5Qkb59Qd72g2vJMI0iFlPj3kf6miMsie/yJ7rt4urJT292HBgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-musl": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.59.0.tgz",
+      "integrity": "sha512-NH579iN8EVQYsWowUB8B5vFchcylJtwPVJ7NmUAqEQHNLfhPbDT3K56KrECNAkUN4QpF4qiMgN2vsfZwVvjm7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-openharmony-arm64": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.59.0.tgz",
+      "integrity": "sha512-mzZy3Z5Aj1D75Aq9FVlmoRQH5ei8Ga4o/NZmlXkKyeZ5EmPrUXRR7c6BMBteV1ZuZ/356UYDuLRLjAMxTDTiBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-arm64-msvc": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.59.0.tgz",
+      "integrity": "sha512-0CpDJ1gE3jN1Gk6xms1Ie6LPfPcOtY4FAtoOmVLHQoAf8DvO2wd0DW2dIX2f7YTp5dxrr0ND8JeUEjm3DP3k5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-ia32-msvc": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.59.0.tgz",
+      "integrity": "sha512-zwdKBu3pt87uW0bRcywZb0oGMS7C6n87qogwRYFUgmk44T90ZzYlPjtlFYXs/DnBFrgNCvlHwCuWKfVWLeE7kw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-x64-msvc": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.59.0.tgz",
+      "integrity": "sha512-dUUbZkKgWrmAeI/puzv4bxN8lzcYaFnQVwFTFtwO2Gp8M7lZGSE2qJjC58g518+1bltJ8mizjYwD0BGHym0l/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1871,16 +2640,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/fs-extra": {
-      "version": "9.0.13",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
-      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2057,19 +2816,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -2154,26 +2900,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
-      "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.6",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.19.tgz",
@@ -2231,27 +2957,13 @@
       }
     },
     "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
+      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/call-me-maybe": {
@@ -2296,19 +3008,6 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2384,16 +3083,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -2422,25 +3111,10 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.415",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.415.tgz",
-      "integrity": "sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==",
+      "version": "1.5.416",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.416.tgz",
+      "integrity": "sha512-K6bvB2BjnNrugtIih6ewlbBI9DXa976jIdiIlRLHhBoEI9a4JaQjjHyF+A1IQI543aQYR4LnmOrT/K5fZj0aPA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2457,26 +3131,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
@@ -2484,33 +3138,46 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
       "dev": true,
+      "hasInstallScript": true,
       "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
+      "bin": {
+        "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
+        "node": ">=18"
       },
-      "engines": {
-        "node": ">= 0.4"
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
       }
     },
     "node_modules/escalade": {
@@ -2532,13 +3199,6 @@
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
-    },
-    "node_modules/eval-estree-expression": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eval-estree-expression/-/eval-estree-expression-3.0.1.tgz",
-      "integrity": "sha512-zTLKGbiVdQYp4rQkSoXPibrFf5ZoPn6jzExegRLEQ13F+FSxu5iLgaRH6hlDs2kWSUa6vp8yD20cdJi0me6pEw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -2592,59 +3252,6 @@
         }
       }
     },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2660,16 +3267,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2678,129 +3275,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/handlebars": {
-      "version": "4.7.9",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
-      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.2",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -2814,20 +3288,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/indent-string": {
@@ -2964,19 +3424,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/lightningcss": {
@@ -3271,45 +3718,12 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -3319,16 +3733,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {
@@ -3355,13 +3759,6 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
-    },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/next": {
       "version": "16.2.9",
@@ -3445,63 +3842,69 @@
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
       "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/openapi-zod-client": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/openapi-zod-client/-/openapi-zod-client-1.18.3.tgz",
-      "integrity": "sha512-10vYK7xo1yyZfcoRvYNGIsDeej1CG9k63u8dkjbGBlr+NHZMy2Iy2h9s11UWNKdj6XMDWbNOPp5gIy8YdpgPtQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@apidevtools/swagger-parser": "^10.1.0",
-        "@liuli-util/fs-extra": "^0.1.0",
-        "@zodios/core": "^10.3.1",
-        "axios": "^1.6.0",
-        "cac": "^6.7.14",
-        "handlebars": "^4.7.7",
-        "openapi-types": "^12.0.2",
-        "openapi3-ts": "3.1.0",
-        "pastable": "^2.2.1",
-        "prettier": "^2.7.1",
-        "tanu": "^0.1.13",
-        "ts-pattern": "^5.0.1",
-        "whence": "^2.0.0",
-        "zod": "^3.19.1"
-      },
-      "bin": {
-        "openapi-zod-client": "bin.js"
-      }
-    },
-    "node_modules/openapi-zod-client/node_modules/@zodios/core": {
-      "version": "10.9.6",
-      "resolved": "https://registry.npmjs.org/@zodios/core/-/core-10.9.6.tgz",
-      "integrity": "sha512-aH4rOdb3AcezN7ws8vDgBfGboZMk2JGGzEq/DtW65MhnRxyTGRuLJRWVQ/2KxDgWvV2F5oTkAS+5pnjKbl0n+A==",
-      "dev": true,
       "license": "MIT",
-      "peerDependencies": {
-        "axios": "^0.x || ^1.0.0",
-        "zod": "^3.x"
-      }
-    },
-    "node_modules/openapi-zod-client/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
+      "peer": true
     },
     "node_modules/openapi3-ts": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-3.1.0.tgz",
-      "integrity": "sha512-1qKTvCCVoV0rkwUh1zq5o8QyghmwYPuhdvtjv1rFjuOnJToXhQyF8eGjNETQ8QmGjr9Jz/tkAKLITIl2s7dw3A==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.6.0.tgz",
+      "integrity": "sha512-a4sfn6L2sIShhtzJqmjGrARvxAW/3F2BJDdyRVvNF9VhAsZSh5hSyI3a9TNvmzBxXmq66nY5LNT5bQcBxYAZZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "yaml": "^2.1.3"
+        "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/oxfmt": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.59.0.tgz",
+      "integrity": "sha512-Xqk6cPZS1yMvVa7OAuenaDZUsgMDutvvbZ9/L5gSvAfW64+WN4HVhgipLj5rVERbYQt8fLs9TopyZ1rU1XEG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinypool": "2.1.0"
+      },
+      "bin": {
+        "oxfmt": "bin/oxfmt"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxfmt/binding-android-arm-eabi": "0.59.0",
+        "@oxfmt/binding-android-arm64": "0.59.0",
+        "@oxfmt/binding-darwin-arm64": "0.59.0",
+        "@oxfmt/binding-darwin-x64": "0.59.0",
+        "@oxfmt/binding-freebsd-x64": "0.59.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.59.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.59.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.59.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.59.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.59.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.59.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.59.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.59.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.59.0",
+        "@oxfmt/binding-linux-x64-musl": "0.59.0",
+        "@oxfmt/binding-openharmony-arm64": "0.59.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.59.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.59.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.59.0"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "svelte": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
       }
     },
     "node_modules/parse5": {
@@ -3597,22 +4000,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -3627,16 +4014,6 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/punycode": {
@@ -3830,16 +4207,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3906,31 +4273,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/tanu": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/tanu/-/tanu-0.1.13.tgz",
-      "integrity": "sha512-UbRmX7ccZ4wMVOY/Uw+7ji4VOkEYSYJG1+I4qzbnn4qh/jtvVbrm6BFnF12NQQ4+jGv21wKmjb1iFyUSVnBWcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.4.0",
-        "typescript": "^4.7.4"
-      }
-    },
-    "node_modules/tanu/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3963,6 +4305,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz",
+      "integrity": "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
       }
     },
     "node_modules/tinyrainbow": {
@@ -4041,6 +4393,25 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/type-fest": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
@@ -4052,6 +4423,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-openapi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typed-openapi/-/typed-openapi-4.0.0.tgz",
+      "integrity": "sha512-s/Pfh6o2DNLD8+4BIxq2hPw7IXbLLcjV8ONi5G0TDbSu3h32Ay7sidVa4lHPc5pq3mNXWKg6Bq2nT6/KDPP8LA==",
+      "dev": true,
+      "dependencies": {
+        "@apidevtools/swagger-parser": "12.1.0",
+        "cac": "7.0.0",
+        "openapi3-ts": "4.6.0",
+        "oxfmt": "0.59.0",
+        "pastable": "2.2.1",
+        "pathe": "2.0.3",
+        "ts-pattern": "5.9.0",
+        "tsx": "4.23.1"
+      },
+      "bin": {
+        "typed-openapi": "bin.js"
       }
     },
     "node_modules/typescript": {
@@ -4066,20 +4456,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/uglify-js": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
-      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/undici": {
@@ -4099,20 +4475,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/update-browserslist-db": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
-      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {
@@ -4385,20 +4751,6 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
-    "node_modules/whence": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/whence/-/whence-2.1.0.tgz",
-      "integrity": "sha512-4UBPMg5mng5KLzdliVQdQ4fJwCdIMXkE8CkoDmGKRy5r8pV9xq+nVgf/sKXpmNEIOtFp7m7v2bFdb7JoLvh+Hg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "eval-estree-expression": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -4415,13 +4767,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "^6.0.0",
         "jsdom": "^30.0.0",
+        "openapi-zod-client": "^1.18.3",
         "typescript": "^6.0.3",
         "vitest": "^4.0.18"
       }
@@ -32,6 +33,60 @@
       "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.7.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.7.2.tgz",
+      "integrity": "sha512-4gY54eEGEstClvEkGnwVkTkrx0sqwemEFG5OSRRn3tD91XH0+Q8XIkYIfo7IwEWPpJZwILb9GUXeShtplRc/eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.1.1.tgz",
+      "integrity": "sha512-u/kozRnsPO/x8QtKYJOqoGtC4kH6yg1lfYkB9Au0WhYB0FNLpyFusttQtvhlwjtG3rOwiRz4D8DnnXa8iEpIKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "11.7.2",
+        "@apidevtools/openapi-schemas": "^2.1.0",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "call-me-maybe": "^1.0.2"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "6.0.7",
@@ -72,12 +127,148 @@
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -88,9 +279,48 @@
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -99,6 +329,54 @@
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -948,12 +1226,73 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@liuli-util/fs-extra": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@liuli-util/fs-extra/-/fs-extra-0.1.0.tgz",
+      "integrity": "sha512-eaAyDyMGT23QuRGbITVY3SOJff3G9ekAAyGqB9joAnTBmqvFN+9a1FazOdO70G6IUqgpKV451eBHYSRcOJ/FNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/fs-extra": "^9.0.13",
+        "fs-extra": "^10.1.0"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.5",
@@ -1532,6 +1871,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.13.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
@@ -1701,6 +2057,51 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1726,6 +2127,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -1746,10 +2154,30 @@
         "node": ">=12"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+      "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.38",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "version": "2.11.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.19.tgz",
+      "integrity": "sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -1768,10 +2196,75 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "funding": [
         {
           "type": "opencollective",
@@ -1803,6 +2296,19 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -1853,12 +2359,40 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -1888,6 +2422,28 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.415",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.415.tgz",
+      "integrity": "sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/entities": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
@@ -1901,12 +2457,71 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
@@ -1918,6 +2533,13 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/eval-estree-expression": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eval-estree-expression/-/eval-estree-expression-3.0.1.tgz",
+      "integrity": "sha512-zTLKGbiVdQYp4rQkSoXPibrFf5ZoPn6jzExegRLEQ13F+FSxu5iLgaRH6hlDs2kWSUa6vp8yD20cdJi0me6pEw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1927,6 +2549,30 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1946,6 +2592,59 @@
         }
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1961,6 +2660,149 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -1972,6 +2814,20 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/indent-string": {
@@ -1996,8 +2852,30 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
-      "peer": true
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsdom": {
       "version": "30.0.1",
@@ -2053,6 +2931,52 @@
       },
       "engines": {
         "node": "^22.14.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/lightningcss": {
@@ -2347,12 +3271,45 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -2363,6 +3320,23 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -2381,6 +3355,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/next": {
       "version": "16.2.9",
@@ -2435,6 +3416,16 @@
         }
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
@@ -2449,6 +3440,70 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/openapi-zod-client": {
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/openapi-zod-client/-/openapi-zod-client-1.18.3.tgz",
+      "integrity": "sha512-10vYK7xo1yyZfcoRvYNGIsDeej1CG9k63u8dkjbGBlr+NHZMy2Iy2h9s11UWNKdj6XMDWbNOPp5gIy8YdpgPtQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "^10.1.0",
+        "@liuli-util/fs-extra": "^0.1.0",
+        "@zodios/core": "^10.3.1",
+        "axios": "^1.6.0",
+        "cac": "^6.7.14",
+        "handlebars": "^4.7.7",
+        "openapi-types": "^12.0.2",
+        "openapi3-ts": "3.1.0",
+        "pastable": "^2.2.1",
+        "prettier": "^2.7.1",
+        "tanu": "^0.1.13",
+        "ts-pattern": "^5.0.1",
+        "whence": "^2.0.0",
+        "zod": "^3.19.1"
+      },
+      "bin": {
+        "openapi-zod-client": "bin.js"
+      }
+    },
+    "node_modules/openapi-zod-client/node_modules/@zodios/core": {
+      "version": "10.9.6",
+      "resolved": "https://registry.npmjs.org/@zodios/core/-/core-10.9.6.tgz",
+      "integrity": "sha512-aH4rOdb3AcezN7ws8vDgBfGboZMk2JGGzEq/DtW65MhnRxyTGRuLJRWVQ/2KxDgWvV2F5oTkAS+5pnjKbl0n+A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "axios": "^0.x || ^1.0.0",
+        "zod": "^3.x"
+      }
+    },
+    "node_modules/openapi-zod-client/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/openapi3-ts": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-3.1.0.tgz",
+      "integrity": "sha512-1qKTvCCVoV0rkwUh1zq5o8QyghmwYPuhdvtjv1rFjuOnJToXhQyF8eGjNETQ8QmGjr9Jz/tkAKLITIl2s7dw3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.1.3"
+      }
+    },
     "node_modules/parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
@@ -2460,6 +3515,32 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pastable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/pastable/-/pastable-2.2.1.tgz",
+      "integrity": "sha512-K4ClMxRKpgN4sXj6VIPPrvor/TMp2yPNCGtfhvV106C73SwefQ3FuegURsH7AQHpqu0WwbvKXRl1HQxF6qax9w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.20.12",
+        "ts-toolbelt": "^9.6.0",
+        "type-fest": "^3.5.3"
+      },
+      "engines": {
+        "node": ">=14.x"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "xstate": ">=4.32.1"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "xstate": {
+          "optional": true
+        }
       }
     },
     "node_modules/pathe": {
@@ -2516,6 +3597,22 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -2530,6 +3627,16 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/punycode": {
@@ -2648,6 +3755,16 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/sharp": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
@@ -2712,6 +3829,16 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -2778,6 +3905,31 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tanu": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/tanu/-/tanu-0.1.13.tgz",
+      "integrity": "sha512-UbRmX7ccZ4wMVOY/Uw+7ji4VOkEYSYJG1+I4qzbnn4qh/jtvVbrm6BFnF12NQQ4+jGv21wKmjb1iFyUSVnBWcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0",
+        "typescript": "^4.7.4"
+      }
+    },
+    "node_modules/tanu/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -2869,11 +4021,38 @@
         "node": ">=20"
       }
     },
+    "node_modules/ts-pattern": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.9.0.tgz",
+      "integrity": "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/typescript": {
       "version": "6.0.3",
@@ -2887,6 +4066,20 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/undici": {
@@ -2905,6 +4098,47 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
     },
     "node_modules/vite": {
       "version": "8.0.16",
@@ -3151,6 +4385,20 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/whence": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/whence/-/whence-2.1.0.tgz",
+      "integrity": "sha512-4UBPMg5mng5KLzdliVQdQ4fJwCdIMXkE8CkoDmGKRy5r8pV9xq+nVgf/sKXpmNEIOtFp7m7v2bFdb7JoLvh+Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.0",
+        "eval-estree-expression": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3168,6 +4416,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -3184,6 +4439,29 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "^6.0.0",
     "jsdom": "^30.0.0",
+    "openapi-zod-client": "^1.18.3",
     "typescript": "^6.0.3",
     "vitest": "^4.0.18"
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "check": "biome check",
     "check:fix": "biome check --write",
     "test": "vitest run --typecheck",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "generate-api": "curl -s ${NEXT_PUBLIC_WAGTAIL_API_HOST:-http://localhost:8000}/api/v3-preview/openapi.json -o lib/generated/openapi.json && typed-openapi lib/generated/openapi.json -r zod --schemas-only --no-runtime-types -o lib/generated/schemas.ts"
   },
   "dependencies": {
     "next": "16.2.9",
@@ -35,7 +36,7 @@
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "^6.0.0",
     "jsdom": "^30.0.0",
-    "openapi-zod-client": "^1.18.3",
+    "typed-openapi": "^4.0.0",
     "typescript": "^6.0.3",
     "vitest": "^4.0.18"
   }


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #11

### Description

Use https://github.com/wagtail/bakerydemo/tree/headless-v3 for the backend

<!-- Please describe the problem you're fixing. -->
Some of the schemas can be generated using ~~openapi-zod-client~~ typed-openapi, but extra handling was required for foreign keys, especially images.

Might worth rethinking how we do FKs in core.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Claude Code with Sonnet 5 in VSCode was used to do the migration. I've made some manual tweaks and done partial review of the changes, but haven't really looked into the `lib/api.ts` changes that much.